### PR TITLE
Fix path traversal vulnerabilities and harden HTTP transport

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,13 @@ ENV DOCS_PATH="./docs"
 ENV SERVER_NAME="LaravelMCPCompanion"
 ENV LOG_LEVEL="INFO"
 
+# Bind all interfaces inside the container; the container network boundary and
+# explicit port publishing are the access control. Outside Docker the server
+# defaults to loopback. The server has no built-in authentication, so only
+# publish this port to networks you trust, and set ALLOWED_HOSTS when serving
+# under a hostname other than localhost.
+ENV HOST=0.0.0.0
+
 
 # Set the entrypoint to the Python script
 ENTRYPOINT ["python", "laravel_mcp_companion.py"]

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ python laravel_mcp_companion.py --transport http \
 Requests with an unrecognized `Host` get `421`; requests from an unlisted `Origin` get `403`. If you expose this beyond localhost, put an authenticating reverse proxy in front of it. Avoid `--transform-mode code` over HTTP entirely — `execute` is a code execution endpoint.
 
 
-## Features (v0.9.0)
+## Features (v0.10.0)
 
 ### Documentation Aggregation
 - **Multi-version Laravel docs** - All versions from 6.x to latest

--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ docker run --rm -i ghcr.io/brianirish/laravel-mcp-companion:latest --force-updat
 | `--force-update` | Force documentation update | false |
 | `--transform-mode MODE` | Tool exposure mode: `search`, `code`, or `none` (env: `TRANSFORM_MODE`) | search |
 | `--host HOST` | Interface to bind in HTTP mode (env: `HOST`) | `127.0.0.1` (`0.0.0.0` in Docker) |
-| `--cors-origin ORIGIN` | Browser origin allowed to call the HTTP transport, repeatable (env: `CORS_ORIGINS`) | none |
-| `--allowed-host HOST` | Host header accepted in HTTP mode, repeatable (env: `ALLOWED_HOSTS`) | localhost only |
+| `--cors-origin ORIGIN` | Browser origin allowed to call the HTTP transport, repeatable (env: `CORS_ORIGINS`) | none (CORS off) |
+| `--allowed-host HOST` | Additional `Host` header accepted in HTTP mode, repeatable (env: `ALLOWED_HOSTS`) | `localhost`, `127.0.0.1`, `::1` |
 
 ### Transform Modes
 
@@ -131,7 +131,7 @@ Defaults are conservative:
 - **Host and Origin validation is on**, which blocks DNS-rebinding and drive-by-localhost attacks from a victim's browser.
 - **CORS is disabled** unless you pass `--cors-origin`. Wildcard origins are rejected; credentials are never allowed cross-origin.
 
-To serve browser clients or a non-loopback interface, list exactly what you trust:
+Only `localhost`, `127.0.0.1`, and `::1` are accepted as `Host` values out of the box. **If you bind a non-loopback interface you must add the hostname clients actually use**, or every request is rejected with `421`:
 
 ```bash
 python laravel_mcp_companion.py --transport http \
@@ -140,7 +140,7 @@ python laravel_mcp_companion.py --transport http \
   --cors-origin https://app.example
 ```
 
-Requests with an unrecognized `Host` get `421`; requests from an unlisted `Origin` get `403`. If you expose this beyond localhost, put an authenticating reverse proxy in front of it. Avoid `--transform-mode code` over HTTP entirely — `execute` is a code execution endpoint.
+Requests with an unrecognized `Host` get `421`; requests from an unlisted `Origin` get `403`. Passing `--allowed-host` or `--cors-origin` on the command line replaces the corresponding environment variable rather than adding to it. If you expose this beyond localhost, put an authenticating reverse proxy in front of it. Avoid `--transform-mode code` over HTTP entirely — `execute` is a code execution endpoint.
 
 
 ## Features (v0.10.0)

--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ docker run --rm -i ghcr.io/brianirish/laravel-mcp-companion:latest --force-updat
 | `--update-docs` | Update documentation on startup | false |
 | `--force-update` | Force documentation update | false |
 | `--transform-mode MODE` | Tool exposure mode: `search`, `code`, or `none` (env: `TRANSFORM_MODE`) | search |
+| `--host HOST` | Interface to bind in HTTP mode (env: `HOST`) | `127.0.0.1` (`0.0.0.0` in Docker) |
+| `--cors-origin ORIGIN` | Browser origin allowed to call the HTTP transport, repeatable (env: `CORS_ORIGINS`) | none |
+| `--allowed-host HOST` | Host header accepted in HTTP mode, repeatable (env: `ALLOWED_HOSTS`) | localhost only |
 
 ### Transform Modes
 
@@ -117,6 +120,27 @@ By default the server no longer lists all of its tools. Instead it exposes a com
 # Restore the old flat tool listing
 docker run --rm -i ghcr.io/brianirish/laravel-mcp-companion:latest --transform-mode none
 ```
+
+### HTTP transport security
+
+**This server ships no authentication.** Anyone who can reach the HTTP port can call every tool, so treat network exposure as granting full access to the documentation tree.
+
+Defaults are conservative:
+
+- **Binds `127.0.0.1`** outside Docker. Inside the container it binds `0.0.0.0`, where the container boundary and explicit `-p` publishing are the access control.
+- **Host and Origin validation is on**, which blocks DNS-rebinding and drive-by-localhost attacks from a victim's browser.
+- **CORS is disabled** unless you pass `--cors-origin`. Wildcard origins are rejected; credentials are never allowed cross-origin.
+
+To serve browser clients or a non-loopback interface, list exactly what you trust:
+
+```bash
+python laravel_mcp_companion.py --transport http \
+  --host 0.0.0.0 \
+  --allowed-host mcp.internal.example \
+  --cors-origin https://app.example
+```
+
+Requests with an unrecognized `Host` get `421`; requests from an unlisted `Origin` get `403`. If you expose this beyond localhost, put an authenticating reverse proxy in front of it. Avoid `--transform-mode code` over HTTP entirely — `execute` is a code execution endpoint.
 
 
 ## Features (v0.9.0)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,7 @@ This roadmap outlines the planned development path toward v1.0.0.
 
 ---
 
-## Current Version: v0.9.0
+## Current Version: v0.10.0
 
 ### ✅ Completed Features
 - **Multi-version Laravel documentation** support (6.x through latest)
@@ -53,8 +53,37 @@ This roadmap outlines the planned development path toward v1.0.0.
 
 ---
 
-## v0.10.0 - MCP Modernization
-**Target: Q2 2026**
+## ✅ v0.10.0 - Security Hardening (COMPLETED)
+**Released: Q3 2026**
+
+Pulled forward from v0.12.0 after an audit found exploitable path traversal in
+tool arguments. Contains breaking changes — see the release notes before upgrading.
+
+### Path Traversal Fixes ✅
+- ✅ Validate the `version` argument against supported versions in every tool
+  (it was joined onto the docs path unchecked, allowing arbitrary `.md` reads)
+- ✅ Single correct containment helper using `resolve()` + `is_relative_to()`,
+  replacing two broken implementations
+- ✅ Validate learning resource `source`/`sources` as real subdirectories
+- ✅ Sanitize remotely-discovered section names before using them as file paths
+- ✅ Validate `version` in `DocsUpdater` before creating directories
+
+### HTTP Transport Hardening ✅
+- ✅ Bind loopback by default instead of all interfaces
+- ✅ Enable Host/Origin validation (blocks DNS rebinding and drive-by localhost)
+- ✅ Require explicit `--cors-origin`; no wildcard reflection with credentials
+- ✅ 47 regression tests covering every traversal
+
+### Performance ✅
+- ✅ Cache-first version lookup with TTL; timeouts on all network calls
+- ✅ Fixed stale documentation served after updates (caches were not all cleared)
+- ✅ Version-scoped search by default; right-sized file cache
+- ✅ One GitHub API call per update instead of three
+
+---
+
+## v0.11.0 - MCP Modernization
+**Target: Q4 2026**
 
 ### MCP 2025-11-25 Spec Compatibility
 - [ ] **Tasks primitive** for async documentation updates and background indexing
@@ -74,18 +103,19 @@ This roadmap outlines the planned development path toward v1.0.0.
 
 ---
 
-## v0.11.0 - Production Readiness
-**Target: Q3 2026**
+## v0.12.0 - Production Readiness
+**Target: Q1 2027**
 
 ### Reliability & Monitoring
 - [ ] Health monitoring and metrics endpoints
 - [ ] Rate limiting and quota management
 - [ ] Error recovery and graceful degradation improvements
-- [ ] Performance optimization and caching improvements
+- [x] Performance optimization and caching improvements *(delivered in v0.10.0)*
 
 ### Security & Stability
-- [ ] Security audit and hardening
-- [ ] Input validation improvements
+- [x] Security audit and hardening *(delivered in v0.10.0)*
+- [x] Input validation improvements *(delivered in v0.10.0)*
+- [ ] Authentication for the HTTP transport
 - [ ] Dependency security scanning
 
 ### Quality Assurance
@@ -96,7 +126,7 @@ This roadmap outlines the planned development path toward v1.0.0.
 ---
 
 ## v1.0.0 - First Stable Release
-**Target: Q4 2026**
+**Target: Q2 2027**
 
 ### Stability Commitments
 - [ ] Feature freeze and API stability
@@ -173,8 +203,13 @@ We welcome community input! If you have ideas, feature requests, or want to cont
 
 ## Versioning Strategy
 
-- **Patch releases (v0.x.y)**: Bug fixes, documentation updates
-- **Minor releases (v0.x.0)**: New features, backward-compatible changes
-- **Major releases (v1.0.0+)**: Stability guarantee, potential breaking changes with migration guides
+We follow [Semantic Versioning](https://semver.org). While the project is on
+`0.x`, the public API is not yet stable and the **minor** version carries
+breaking changes:
 
-Each release maintains backward compatibility within the same major version.
+- **Patch releases (v0.x.y)**: Bug fixes, documentation updates
+- **Minor releases (v0.x.0)**: New features, and breaking changes where needed,
+  called out in the release notes
+- **v1.0.0 onward**: Breaking changes only in major releases, with migration guides
+
+Backward compatibility is guaranteed within a major version starting at v1.0.0.

--- a/docs_updater.py
+++ b/docs_updater.py
@@ -154,14 +154,22 @@ def is_safe_section_name(name: str) -> bool:
         return False
     if '..' in name or name.startswith('/') or '\\' in name or '\x00' in name:
         return False
+    # Reject dot and empty components. "." is otherwise accepted by the pattern
+    # below, and `base / "."` collapses to `base` itself, which would silently
+    # retarget a version directory at the whole documentation root.
+    if any(part in ('', '.', '..') for part in name.split('/')):
+        return False
     return _SAFE_PATH_SEGMENT.fullmatch(name) is not None
 
 
 def is_within_directory(base_dir: Path, target: Path) -> bool:
-    """Check that target resolves to a location inside base_dir."""
+    """Check that target resolves to a location inside base_dir.
+
+    Fails closed: any error resolving either path denies the write.
+    """
     try:
         return target.resolve().is_relative_to(base_dir.resolve())
-    except (OSError, ValueError):
+    except Exception:
         return False
 
 
@@ -1469,9 +1477,12 @@ class DocsUpdater:
         self.github_api_url = GITHUB_API_URL
         self.repo = LARAVEL_DOCS_REPO
 
-        # Create version-specific directory
+        # Create version-specific directory. update() clears everything under
+        # version_dir, so it must be a strict subdirectory of target_dir --
+        # equality would wipe every version in the documentation root.
         self.version_dir = target_dir / version
-        if not is_within_directory(target_dir, self.version_dir):
+        if (not is_within_directory(target_dir, self.version_dir)
+                or self.version_dir.resolve() == target_dir.resolve()):
             raise ValueError(f"Version directory escapes target directory: {version!r}")
         self.version_dir.mkdir(parents=True, exist_ok=True)
         

--- a/docs_updater.py
+++ b/docs_updater.py
@@ -132,6 +132,38 @@ VERSIONS_CACHE_FILE = Path(__file__).parent / "docs" / ".versions_cache.json"
 
 LAST_RESORT_VERSIONS = ["12.x"]
 
+# Network timeout for documentation fetches. Without this, urllib blocks
+# indefinitely and a stalled connection hangs startup or pins a worker thread.
+DEFAULT_REQUEST_TIMEOUT = 30
+
+# How long a cached version list stays fresh before we ask GitHub again.
+VERSIONS_CACHE_TTL_SECONDS = 24 * 60 * 60
+
+# Section/version names become filesystem paths, so they are restricted to a
+# conservative character set: alphanumerics, dot, dash, underscore, and single
+# forward slashes for nesting. No leading slash, no '..', no backslash, no NUL.
+_SAFE_PATH_SEGMENT = re.compile(r'[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)*')
+
+
+def is_safe_section_name(name: str) -> bool:
+    """Check that a discovered section name is safe to use as a relative path.
+
+    Section names are parsed out of remote HTML, so they are untrusted input.
+    """
+    if not name or len(name) > 255:
+        return False
+    if '..' in name or name.startswith('/') or '\\' in name or '\x00' in name:
+        return False
+    return _SAFE_PATH_SEGMENT.fullmatch(name) is not None
+
+
+def is_within_directory(base_dir: Path, target: Path) -> bool:
+    """Check that target resolves to a location inside base_dir."""
+    try:
+        return target.resolve().is_relative_to(base_dir.resolve())
+    except (OSError, ValueError):
+        return False
+
 
 def _write_versions_cache(versions: list[str], cache_file: Path) -> None:
     """Write versions to cache file. Errors are logged but not raised."""
@@ -145,16 +177,38 @@ def _write_versions_cache(versions: list[str], cache_file: Path) -> None:
         logger.warning(f"Failed to write versions cache: {e}")
 
 
-def _read_versions_cache(cache_file: Path) -> list[str] | None:
-    """Read versions from cache file. Returns None if unavailable or corrupt."""
+def _read_versions_cache(cache_file: Path, max_age_seconds: float | None = None) -> list[str] | None:
+    """Read versions from cache file. Returns None if unavailable or corrupt.
+
+    Args:
+        cache_file: Path to the cache file.
+        max_age_seconds: If set, ignore the cache when its timestamp is older
+            than this (or missing/unparseable).
+    """
     try:
         if not cache_file.exists():
             return None
         data = json.loads(cache_file.read_text())
         versions = data.get("versions")
-        if isinstance(versions, list) and len(versions) > 0:
-            return versions
-        return None
+        if not (isinstance(versions, list) and len(versions) > 0):
+            return None
+
+        if max_age_seconds is not None:
+            updated_at = data.get("updated_at")
+            if not updated_at:
+                return None
+            try:
+                cached_at = datetime.fromisoformat(updated_at)
+            except (TypeError, ValueError):
+                return None
+            if cached_at.tzinfo is None:
+                cached_at = cached_at.replace(tzinfo=timezone.utc)
+            age = (datetime.now(timezone.utc) - cached_at).total_seconds()
+            if age > max_age_seconds:
+                logger.debug(f"Versions cache is stale ({age:.0f}s old)")
+                return None
+
+        return versions
     except Exception as e:
         logger.warning(f"Failed to read versions cache: {e}")
         return None
@@ -163,9 +217,13 @@ def _read_versions_cache(cache_file: Path) -> list[str] | None:
 def get_supported_versions(cache_file: Path | None = None) -> list[str]:
     """Get supported Laravel versions with three-tier fallback.
 
-    1. GitHub API (writes cache on success)
-    2. Cache file (docs/.versions_cache.json)
-    3. Last resort: ["12.x"]
+    1. Fresh cache file (docs/.versions_cache.json, younger than the TTL)
+    2. GitHub API (writes cache on success)
+    3. Stale cache file, then last resort: ["12.x"]
+
+    This runs at import time, so the cache is consulted first: a network round
+    trip on every process start is wasteful, and a stalled connection would
+    otherwise block startup.
 
     Args:
         cache_file: Override cache file path (for testing). Defaults to VERSIONS_CACHE_FILE.
@@ -175,6 +233,11 @@ def get_supported_versions(cache_file: Path | None = None) -> list[str]:
     """
     if cache_file is None:
         cache_file = VERSIONS_CACHE_FILE
+
+    fresh = _read_versions_cache(cache_file, max_age_seconds=VERSIONS_CACHE_TTL_SECONDS)
+    if fresh:
+        logger.debug(f"Using cached Laravel versions: {', '.join(fresh)}")
+        return fresh
 
     logger.debug("Fetching supported Laravel versions from GitHub API")
 
@@ -189,7 +252,7 @@ def get_supported_versions(cache_file: Path | None = None) -> list[str]:
             }
         )
 
-        with urllib.request.urlopen(request) as response:
+        with urllib.request.urlopen(request, timeout=DEFAULT_REQUEST_TIMEOUT) as response:
             branches = json.loads(response.read().decode())
 
             version_branches = []
@@ -565,7 +628,7 @@ class DocumentationAutoDiscovery:
                     time.sleep(self.request_delay * (2 ** (attempt - 1)))
                 
                 request = urllib.request.Request(url, headers=headers)
-                with urllib.request.urlopen(request) as response:
+                with urllib.request.urlopen(request, timeout=DEFAULT_REQUEST_TIMEOUT) as response:
                     return response.read()
                     
             except urllib.error.HTTPError as e:
@@ -874,9 +937,19 @@ class ExternalDocsFetcher:
             if self.auto_discovery._is_asset_file(section):
                 logger.debug(f"Skipping asset file: {section}")
                 continue
-                
+
+            # Section names come from remote HTML and are used as file paths
+            if not is_safe_section_name(section):
+                logger.warning(f"Skipping section with unsafe name for {service}: {section!r}")
+                continue
+
             section_url = f"{base_url}/{section}"
             section_file = target_dir / f"{section}.md"
+
+            # Defence in depth: reject anything that still escapes the target dir
+            if not is_within_directory(target_dir, section_file):
+                logger.warning(f"Skipping out-of-tree section path for {service}: {section!r}")
+                continue
             
             # Create parent directories if needed for nested sections
             section_file.parent.mkdir(parents=True, exist_ok=True)
@@ -1329,7 +1402,7 @@ class ExternalDocsFetcher:
         for attempt in range(retries + 1):
             try:
                 request = urllib.request.Request(url, headers=headers)
-                with urllib.request.urlopen(request) as response:
+                with urllib.request.urlopen(request, timeout=DEFAULT_REQUEST_TIMEOUT) as response:
                     return response.read()
             except urllib.error.HTTPError as e:
                 last_exception = e
@@ -1386,13 +1459,20 @@ class DocsUpdater:
             target_dir: Directory where docs should be stored
             version: Laravel version branch to pull documentation from (e.g., "12.x")
         """
+        # `version` is joined onto target_dir, so validate before any mkdir.
+        # Callers include MCP tools, which may pass caller-supplied values.
+        if not is_safe_section_name(version) or '/' in version:
+            raise ValueError(f"Invalid Laravel version: {version!r}")
+
         self.target_dir = target_dir
         self.version = version
         self.github_api_url = GITHUB_API_URL
         self.repo = LARAVEL_DOCS_REPO
-        
+
         # Create version-specific directory
         self.version_dir = target_dir / version
+        if not is_within_directory(target_dir, self.version_dir):
+            raise ValueError(f"Version directory escapes target directory: {version!r}")
         self.version_dir.mkdir(parents=True, exist_ok=True)
         
         # Create metadata directory if it doesn't exist
@@ -1417,7 +1497,7 @@ class DocsUpdater:
                     }
                 )
                 
-                with urllib.request.urlopen(request) as response:
+                with urllib.request.urlopen(request, timeout=DEFAULT_REQUEST_TIMEOUT) as response:
                     data = json.loads(response.read().decode())
                     return {
                         "sha": data["commit"]["sha"],
@@ -1517,7 +1597,7 @@ class DocsUpdater:
                         headers={"User-Agent": USER_AGENT}
                     )
 
-                    with urllib.request.urlopen(request) as response, open(zip_path, 'wb') as out_file:
+                    with urllib.request.urlopen(request, timeout=DEFAULT_REQUEST_TIMEOUT) as response, open(zip_path, 'wb') as out_file:
                         shutil.copyfileobj(response, out_file)
                     break  # Success, exit retry loop
                 except Exception as e:
@@ -1549,12 +1629,18 @@ class DocsUpdater:
             logger.error(f"Error downloading documentation: {str(e)}")
             raise
     
-    def needs_update(self) -> bool:
-        """Check if documentation needs to be updated based on remote commits."""
+    def needs_update(self, latest_commit: Optional[Dict[str, str]] = None) -> bool:
+        """Check if documentation needs to be updated based on remote commits.
+
+        Args:
+            latest_commit: Already-fetched commit info, to avoid a redundant
+                GitHub API request (the unauthenticated limit is 60/hour).
+        """
         try:
             # Get the latest commit info
-            latest_commit = self.get_latest_commit()
-            
+            if latest_commit is None:
+                latest_commit = self.get_latest_commit()
+
             # Get local metadata
             local_meta = self.read_local_metadata()
             
@@ -1580,13 +1666,24 @@ class DocsUpdater:
         Returns:
             True if update was performed, False otherwise
         """
-        if not force and not self.needs_update():
-            return False
-        
+        # Fetch the commit once and reuse it for both the up-to-date check and
+        # the metadata written below, instead of hitting the API twice.
+        latest_commit: Optional[Dict[str, str]] = None
+        if not force:
+            try:
+                latest_commit = self.get_latest_commit()
+            except Exception as e:
+                logger.error(f"Error checking for updates: {str(e)}")
+                logger.info("Assuming update is needed due to error")
+
+            if latest_commit is not None and not self.needs_update(latest_commit):
+                return False
+
         try:
             # Get the latest commit info for metadata
-            latest_commit = self.get_latest_commit()
-            
+            if latest_commit is None:
+                latest_commit = self.get_latest_commit()
+
             # Download the documentation
             source_dir = self.download_documentation()
             
@@ -1966,7 +2063,7 @@ class CommunityPackageFetcher:
                     headers={"User-Agent": "Laravel-MCP-Companion/1.0"}
                 )
                 
-                with urllib.request.urlopen(request) as response:
+                with urllib.request.urlopen(request, timeout=DEFAULT_REQUEST_TIMEOUT) as response:
                     jsx_content = response.read().decode('utf-8')
                 
                 # Extract content from JSX file and convert to markdown
@@ -2281,7 +2378,7 @@ class CommunityPackageFetcher:
                 headers={"User-Agent": USER_AGENT}
             )
             
-            with urllib.request.urlopen(request) as response:
+            with urllib.request.urlopen(request, timeout=DEFAULT_REQUEST_TIMEOUT) as response:
                 content = response.read().decode('utf-8')
             
             # Process the README content
@@ -2342,7 +2439,7 @@ class CommunityPackageFetcher:
                 }
             )
             
-            with urllib.request.urlopen(request, timeout=30) as response:
+            with urllib.request.urlopen(request, timeout=DEFAULT_REQUEST_TIMEOUT) as response:
                 content_bytes = response.read()
                 content = content_bytes.decode('utf-8')
             
@@ -3419,7 +3516,7 @@ class LearningResourceFetcher:
         for attempt in range(self.max_retries + 1):
             try:
                 request = urllib.request.Request(url, headers=headers)
-                with urllib.request.urlopen(request, timeout=30) as response:
+                with urllib.request.urlopen(request, timeout=DEFAULT_REQUEST_TIMEOUT) as response:
                     return response.read()
             except urllib.error.HTTPError as e:
                 last_exception = e

--- a/laravel_mcp_companion.py
+++ b/laravel_mcp_companion.py
@@ -15,7 +15,6 @@ import argparse
 import json
 from pathlib import Path
 from typing import Dict, Optional, List, Any
-from functools import lru_cache
 import threading
 from fastmcp import FastMCP
 from fastmcp.server.transforms.search import BM25SearchTransform
@@ -48,7 +47,11 @@ from mcp_tools import (
     get_related_laravel_packages_impl,
     search_laravel_learning_resources_impl,
     list_laravel_learning_resources_impl,
-    list_laravel_categories_impl
+    list_laravel_categories_impl,
+    is_safe_path,
+    validate_version as validate_version_arg,
+    count_matches,
+    clear_caches as clear_mcp_tools_caches
 )
 
 # Import learning resources
@@ -646,6 +649,13 @@ When to use:
 - Planning what to learn next"""
 }
 
+def _split_env_list(env_var: str) -> Optional[List[str]]:
+    """Parse a comma-separated environment variable into a list of values."""
+    raw = os.environ.get(env_var, "")
+    values = [item.strip() for item in raw.split(",") if item.strip()]
+    return values or None
+
+
 def parse_arguments():
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(
@@ -708,6 +718,23 @@ def parse_arguments():
         help="Force update of documentation even if already up to date (env: FORCE_UPDATE=true)"
     )
     parser.add_argument(
+        "--cors-origin",
+        action="append",
+        default=_split_env_list("CORS_ORIGINS"),
+        metavar="ORIGIN",
+        help="Browser origin allowed to call the HTTP transport (repeatable). "
+             "CORS is disabled unless at least one origin is given. "
+             "Wildcards are not accepted (env: CORS_ORIGINS, comma-separated)"
+    )
+    parser.add_argument(
+        "--allowed-host",
+        action="append",
+        default=_split_env_list("ALLOWED_HOSTS"),
+        metavar="HOST",
+        help="Host header value accepted by the HTTP transport (repeatable). "
+             "Required to serve on a non-loopback interface (env: ALLOWED_HOSTS, comma-separated)"
+    )
+    parser.add_argument(
         "--transform-mode",
         type=str,
         default=os.environ.get("TRANSFORM_MODE", "").lower() or None,
@@ -743,18 +770,13 @@ def setup_docs_path(user_path: Optional[str] = None) -> Path:
     
     return docs_path
 
-def is_safe_path(base_path: Path, path: Path) -> bool:
-    """Check if a path is safe (doesn't escape the base directory)."""
-    return base_path in path.absolute().parents or base_path == path.absolute()
-
-@lru_cache(maxsize=100)
 def get_file_content_cached(file_path: str) -> str:
     """
-    Get file content with caching.
-    
+    Get file content, keyed on path and modification time.
+
     Args:
         file_path: Absolute path to the file
-        
+
     Returns:
         File content as string
     """
@@ -762,46 +784,49 @@ def get_file_content_cached(file_path: str) -> str:
         path_obj = Path(file_path)
         if not path_obj.exists():
             return f"File not found: {file_path}"
-        
+
         # Check file modification time for cache invalidation
         mtime = path_obj.stat().st_mtime
         cache_key = f"{file_path}:{mtime}"
-        
+
         with _cache_lock:
             if cache_key in _file_content_cache:
                 return _file_content_cache[cache_key]
-        
+
         # Read file content
         with open(path_obj, 'r', encoding='utf-8') as f:
             content = f.read()
-        
+
         # Cache the content
         with _cache_lock:
-            # Clear old cache entries for this file
+            # Clear stale entries for this file (previous mtimes)
             keys_to_remove = [k for k in _file_content_cache.keys() if k.startswith(f"{file_path}:")]
             for key in keys_to_remove:
                 del _file_content_cache[key]
-            
+
             # Add new cache entry
             _file_content_cache[cache_key] = content
-            
+
             # Limit cache size
             if len(_file_content_cache) > 200:
                 # Remove oldest entries
                 oldest_keys = list(_file_content_cache.keys())[:50]
                 for key in oldest_keys:
                     del _file_content_cache[key]
-        
+
         return content
     except Exception as e:
         logger.error(f"Error reading file {file_path}: {str(e)}")
         return f"Error reading file: {str(e)}"
 
 def clear_file_cache():
-    """Clear the file content cache."""
+    """Clear every documentation cache, in this module and in mcp_tools."""
     with _cache_lock:
         _file_content_cache.clear()
         _search_result_cache.clear()
+    # The tool implementations keep their own caches; stale entries there would
+    # otherwise survive a docs update until the process restarts.
+    clear_mcp_tools_caches()
 
 def update_documentation(docs_path: Path, version: str, force: bool = False) -> bool:
     """Update the documentation if needed or forced."""
@@ -882,10 +907,10 @@ def search_by_use_case(use_case: str) -> List[Dict]:
     words = words - stop_words
     
     # Score packages based on matching words
-    scores = {}
+    scores: Dict[str, float] = {}
     for pkg_id, pkg_info in PACKAGE_CATALOG.items():
-        score = 0
-        
+        score = 0.0
+
         # Check categories
         for category in pkg_info.get('categories', []):
             if any(word in category.lower() for word in words):
@@ -902,7 +927,7 @@ def search_by_use_case(use_case: str) -> List[Dict]:
         name_desc = (str(pkg_info.get('name', '')) + ' ' + str(pkg_info.get('description', ''))).lower()
         for word in words:
             if word in name_desc:
-                score += int(0.5)
+                score += 0.5
         
         if score > 0:
             scores[pkg_id] = score
@@ -1353,16 +1378,17 @@ def configure_mcp_server(mcp: FastMCP, docs_path: Path, runtime_version: str, mu
         annotations={"readOnlyHint": True, "idempotentHint": True},
         tags={"docs", "read"}
     )
-    def search_laravel_docs(query: str, version: Optional[str] = None, include_external: bool = True) -> str:
+    def search_laravel_docs(query: str, version: Optional[str] = None, include_external: bool = True, all_versions: bool = False) -> str:
         """Search through Laravel documentation for a specific term.
 
         Args:
             query: Search term to look for
-            version: Specific Laravel version to search (e.g., "12.x"). If not provided, searches all versions.
+            version: Specific Laravel version to search (e.g., "12.x"). Defaults to the configured version.
             include_external: Whether to include external Laravel services documentation in search
+            all_versions: Search every supported version instead of just the configured one
         """
         external_dir = multi_updater.external_fetcher.external_dir if include_external else None
-        return search_laravel_docs_impl(docs_path, query, version, include_external, external_dir, runtime_version=runtime_version)
+        return search_laravel_docs_impl(docs_path, query, version, include_external, external_dir, runtime_version=runtime_version, all_versions=all_versions)
     
     @mcp.tool(
         description=TOOL_DESCRIPTIONS["update_laravel_docs"],
@@ -1379,34 +1405,34 @@ def configure_mcp_server(mcp: FastMCP, docs_path: Path, runtime_version: str, mu
             force: Force update even if already up to date
         """
         logger.debug(f"update_laravel_docs function called (version: {version_param}, force: {force})")
-        
+
         # Use provided version or default to the one specified at startup
         doc_version = version_param or runtime_version
-        
+
+        version_error = validate_version_arg(version_param)
+        if version_error:
+            return version_error
+
         try:
             updater = DocsUpdater(docs_path, doc_version)
-            
-            # Check if update is needed
-            if not force and not updater.needs_update():
-                return f"Documentation is already up to date (version: {doc_version})"
-            
-            # Perform the update
+
+            # update() performs its own needs_update() check; calling it here too
+            # would spend an extra unauthenticated GitHub API request (60/hr limit).
             updated = updater.update(force=force)
-            
-            if updated:
-                # Clear caches when documentation is updated
-                clear_file_cache()
-                get_file_content_cached.cache_clear()
-                
-                metadata = get_laravel_docs_metadata(docs_path, doc_version)
-                return (
-                    f"Documentation updated successfully to {doc_version}\n"
-                    f"Commit: {metadata.get('commit_sha', 'unknown')[:7]}\n"
-                    f"Date: {metadata.get('commit_date', 'unknown')}\n"
-                    f"Message: {metadata.get('commit_message', 'unknown')}"
-                )
-            else:
-                return "Documentation update not performed or not needed"
+
+            if not updated:
+                return f"Documentation is already up to date (version: {doc_version})"
+
+            # Clear caches when documentation is updated
+            clear_file_cache()
+
+            metadata = get_laravel_docs_metadata(docs_path, doc_version)
+            return (
+                f"Documentation updated successfully to {doc_version}\n"
+                f"Commit: {metadata.get('commit_sha', 'unknown')[:7]}\n"
+                f"Date: {metadata.get('commit_date', 'unknown')}\n"
+                f"Message: {metadata.get('commit_message', 'unknown')}"
+            )
         except Exception as e:
             logger.error(f"Error updating documentation: {str(e)}")
             return f"Error updating documentation: {str(e)}"
@@ -1626,22 +1652,24 @@ def configure_mcp_server(mcp: FastMCP, docs_path: Path, runtime_version: str, mu
         query: str,
         version: Optional[str] = None,
         context_length: int = 200,
-        include_external: bool = True
+        include_external: bool = True,
+        all_versions: bool = False
     ) -> str:
         """
         Search through Laravel documentation with context snippets.
-        
+
         Args:
             query: Search term
-            version: Specific version or None for all
+            version: Specific version, or None for the configured version
             context_length: Characters of context to show (default: 200)
             include_external: Whether to include external Laravel services documentation
-        
+            all_versions: Search every supported version instead of just the configured one
+
         Returns:
             Search results with context snippets
         """
         external_dir = multi_updater.external_fetcher.external_dir if include_external else None
-        return search_laravel_docs_with_context_impl(docs_path, query, version, context_length, include_external, external_dir, runtime_version=runtime_version)
+        return search_laravel_docs_with_context_impl(docs_path, query, version, context_length, include_external, external_dir, runtime_version=runtime_version, all_versions=all_versions)
 
     @mcp.tool(
         description="Get the structure and sections of a documentation file",
@@ -1746,8 +1774,7 @@ def configure_mcp_server(mcp: FastMCP, docs_path: Path, runtime_version: str, mu
             
             if successful:
                 clear_file_cache()
-                get_file_content_cached.cache_clear()
-            
+
             response = []
             response.append("External Laravel Services Documentation Update Results:")
             response.append(f"Successfully updated: {len(successful)}/{len(results)} services")
@@ -1856,14 +1883,13 @@ def configure_mcp_server(mcp: FastMCP, docs_path: Path, runtime_version: str, mu
                 service_matches: List[Dict[str, Any]] = []
                 for file_path in service_dir.glob("*.md"):
                     try:
-                        with open(file_path, 'r', encoding='utf-8') as f:
-                            content = f.read()
-                            if pattern.search(content):
-                                count = len(pattern.findall(content))
-                                service_matches.append({
-                                    "file": file_path.name,
-                                    "matches": count
-                                })
+                        content = get_file_content_cached(str(file_path))
+                        count = count_matches(pattern, content)
+                        if count:
+                            service_matches.append({
+                                "file": file_path.name,
+                                "matches": count
+                            })
                     except Exception as e:
                         logger.warning(f"Error searching {file_path}: {str(e)}")
                         continue
@@ -2193,23 +2219,47 @@ def main():
             import uvicorn
             from starlette.middleware.cors import CORSMiddleware
 
-            # Get the FastMCP HTTP app
-            app = mcp.http_app()
+            # Use PORT from environment or args, default to 8081.
+            # Bind loopback by default: this server ships no authentication, so
+            # every tool is exposed to anyone who can reach the socket.
+            port = args.port if args.port else 8081
+            host = args.host or "127.0.0.1"
+            is_loopback = host in ("127.0.0.1", "::1", "localhost")
 
-            # Add CORS middleware for browser-based clients
-            app.add_middleware(
-                CORSMiddleware,
-                allow_origins=["*"],
-                allow_credentials=True,
-                allow_methods=["GET", "POST", "OPTIONS"],
-                allow_headers=["*"],
-                expose_headers=["mcp-session-id", "mcp-protocol-version"],
-                max_age=86400,
+            cors_origins = [o for o in (args.cors_origin or []) if o != "*"]
+            if args.cors_origin and not cors_origins:
+                logger.error("Wildcard CORS origins are not supported; pass explicit origins")
+                sys.exit(1)
+
+            if not is_loopback:
+                logger.warning(
+                    f"Binding {host} exposes an unauthenticated MCP server to the network. "
+                    "Restrict access at the network layer and set --allowed-host."
+                )
+
+            # Enable FastMCP's Host/Origin guard (off by default upstream). Strict
+            # mode is required off-loopback, where the 'auto' heuristic disengages.
+            app = mcp.http_app(
+                host_origin_protection="auto" if is_loopback else True,
+                allowed_hosts=args.allowed_host or None,
+                allowed_origins=cors_origins or None,
             )
 
-            # Use PORT from environment or args, default to 8081
-            port = args.port if args.port else 8081
-            host = args.host or "0.0.0.0"
+            # Browser clients need CORS; everything else does not. Only add the
+            # middleware when explicit origins are configured, and never reflect
+            # arbitrary origins with credentials attached.
+            if cors_origins:
+                app.add_middleware(
+                    CORSMiddleware,
+                    allow_origins=cors_origins,
+                    allow_credentials=False,
+                    allow_methods=["GET", "POST", "OPTIONS"],
+                    allow_headers=["content-type", "mcp-session-id", "mcp-protocol-version", "authorization"],
+                    expose_headers=["mcp-session-id", "mcp-protocol-version"],
+                    max_age=86400,
+                )
+                logger.info(f"CORS enabled for: {', '.join(cors_origins)}")
+
             logger.info(f"Listening on {host}:{port}")
 
             uvicorn.run(app, host=host, port=port, log_level="info")

--- a/laravel_mcp_companion.py
+++ b/laravel_mcp_companion.py
@@ -717,22 +717,27 @@ def parse_arguments():
         default=os.environ.get("FORCE_UPDATE", "").lower() == "true",
         help="Force update of documentation even if already up to date (env: FORCE_UPDATE=true)"
     )
+    # These default to None rather than the env list: argparse's "append" action
+    # appends to the default, so a non-empty default would union env values with
+    # CLI values instead of letting the CLI replace them. The env fallback is
+    # applied below, only when the flag is absent.
     parser.add_argument(
         "--cors-origin",
         action="append",
-        default=_split_env_list("CORS_ORIGINS"),
+        default=None,
         metavar="ORIGIN",
         help="Browser origin allowed to call the HTTP transport (repeatable). "
-             "CORS is disabled unless at least one origin is given. "
-             "Wildcards are not accepted (env: CORS_ORIGINS, comma-separated)"
+             "Replaces CORS_ORIGINS when given. CORS is disabled unless at least "
+             "one origin is set. Wildcards are not accepted (env: CORS_ORIGINS, comma-separated)"
     )
     parser.add_argument(
         "--allowed-host",
         action="append",
-        default=_split_env_list("ALLOWED_HOSTS"),
+        default=None,
         metavar="HOST",
         help="Host header value accepted by the HTTP transport (repeatable). "
-             "Required to serve on a non-loopback interface (env: ALLOWED_HOSTS, comma-separated)"
+             "Replaces ALLOWED_HOSTS when given. Required to serve under a hostname "
+             "other than localhost (env: ALLOWED_HOSTS, comma-separated)"
     )
     parser.add_argument(
         "--transform-mode",
@@ -754,6 +759,13 @@ def parse_arguments():
     # argparse does not validate defaults against choices, so check env-provided values
     if args.transform_mode is not None and args.transform_mode not in ("search", "code", "none"):
         parser.error(f"invalid TRANSFORM_MODE: {args.transform_mode!r} (choose from 'search', 'code', 'none')")
+
+    # Fall back to the environment only when the flag was not given, so an
+    # explicit allowlist on the command line fully replaces the env value.
+    if args.cors_origin is None:
+        args.cors_origin = _split_env_list("CORS_ORIGINS") or []
+    if args.allowed_host is None:
+        args.allowed_host = _split_env_list("ALLOWED_HOSTS") or []
 
     return args
 
@@ -1884,6 +1896,11 @@ def configure_mcp_server(mcp: FastMCP, docs_path: Path, runtime_version: str, mu
                 for file_path in service_dir.glob("*.md"):
                     try:
                         content = get_file_content_cached(str(file_path))
+                        # The cached reader signals failure with a sentinel string;
+                        # matching against it would fabricate hits for queries like
+                        # "error" or "file" on a file that was never read.
+                        if content.startswith("Error") or content.startswith("File not found"):
+                            continue
                         count = count_matches(pattern, content)
                         if count:
                             service_matches.append({

--- a/mcp_tools.py
+++ b/mcp_tools.py
@@ -530,7 +530,7 @@ def search_laravel_docs_with_context_impl(docs_path: Path, query: str, version: 
         if results:
             return f"Search results for '{query}':\n" + "".join(results)
         else:
-            search_scope = f"version {version}" if version else "all sources"
+            search_scope = f"version {version}" if version else f"versions {', '.join(search_versions)}"
             return f"No results found for '{query}' in {search_scope}"
             
     except Exception as e:

--- a/mcp_tools.py
+++ b/mcp_tools.py
@@ -51,7 +51,15 @@ logger = logging.getLogger("laravel-mcp-companion")
 # Get supported versions
 SUPPORTED_VERSIONS = get_cached_supported_versions()
 
-# Global caches for performance optimization
+# Global caches for performance optimization.
+# A single version of the Laravel docs is ~103 files, so a 100-entry cache was
+# evicted continuously by any full-corpus search. Size it to hold several
+# versions plus external service docs.
+_FILE_CACHE_MAX_ENTRIES = 512
+_FILE_CACHE_EVICT_COUNT = 64
+_SEARCH_CACHE_MAX_ENTRIES = 100
+_SEARCH_CACHE_EVICT_COUNT = 20
+
 _file_content_cache: Dict[str, str] = {}
 _search_result_cache: Dict[str, str] = {}
 _cache_lock = threading.Lock()
@@ -63,21 +71,21 @@ def get_file_content_cached(file_path: str) -> str:
         if file_path in _file_content_cache:
             logger.debug(f"Cache hit for file: {file_path}")
             return _file_content_cache[file_path]
-    
+
     try:
         with open(file_path, 'r', encoding='utf-8') as f:
             content = f.read()
-        
+
         # Cache the content
         with _cache_lock:
             _file_content_cache[file_path] = content
             # Limit cache size to prevent memory issues
-            if len(_file_content_cache) > 100:
+            if len(_file_content_cache) > _FILE_CACHE_MAX_ENTRIES:
                 # Remove oldest entries
-                oldest_keys = list(_file_content_cache.keys())[:20]
+                oldest_keys = list(_file_content_cache.keys())[:_FILE_CACHE_EVICT_COUNT]
                 for key in oldest_keys:
                     del _file_content_cache[key]
-        
+
         return content
     except FileNotFoundError:
         return f"File not found: {file_path}"
@@ -107,16 +115,75 @@ def get_version_from_path(path: str, runtime_version: Optional[str] = None) -> t
 
 
 def is_safe_path(base_path: Path, target_path: Path) -> bool:
-    """Check if target path is within base path (prevent directory traversal)."""
+    """Check if target path is within base path (prevent directory traversal).
+
+    Uses is_relative_to() on fully resolved paths. A plain string prefix check is
+    not sufficient: it treats "/docs/12.x-backup" as living under "/docs/12.x".
+
+    Fails closed: any error resolving either path denies access.
+    """
     try:
-        # Resolve both paths to handle any .. or . components
-        base = base_path.resolve()
-        target = target_path.resolve()
-        
-        # Check if target is within base
-        return str(target).startswith(str(base))
+        return Path(target_path).resolve().is_relative_to(Path(base_path).resolve())
     except Exception:
         return False
+
+
+def validate_version(version: Optional[str]) -> Optional[str]:
+    """Validate a caller-supplied Laravel version against the supported allowlist.
+
+    Version strings are used to build filesystem paths, so anything outside the
+    allowlist is rejected before it can be joined onto a base directory.
+
+    Returns:
+        A TOON-encoded error string if the version is invalid, otherwise None.
+    """
+    if version is not None and version not in SUPPORTED_VERSIONS:
+        logger.warning(f"Rejected unsupported version parameter: {version!r}")
+        return format_error(
+            f"Invalid version: {version}",
+            {"supported_versions": SUPPORTED_VERSIONS}
+        )
+    return None
+
+
+def resolve_search_versions(
+    version: Optional[str],
+    runtime_version: Optional[str] = None,
+    all_versions: bool = False,
+) -> List[str]:
+    """Decide which versions a search should cover.
+
+    Searching every supported version re-reads the entire corpus and returns
+    near-duplicate hits for the same file, so scope defaults to the configured
+    version unless the caller explicitly asks for all of them.
+    """
+    if version:
+        return [version]
+    if all_versions:
+        return list(SUPPORTED_VERSIONS)
+    default = runtime_version or DEFAULT_VERSION
+    return [default] if default in SUPPORTED_VERSIONS else list(SUPPORTED_VERSIONS)
+
+
+def count_matches(pattern: re.Pattern, content: str) -> int:
+    """Count regex matches in a single pass.
+
+    Replaces the search()-then-findall() pattern, which scanned each file twice
+    and materialized every match just to take its length.
+    """
+    return sum(1 for _ in pattern.finditer(content))
+
+
+def validate_subdirectory(base_dir: Path, name: str) -> bool:
+    """Check that `name` refers to a direct subdirectory of base_dir.
+
+    Guards caller-supplied directory names (learning resource sources, service
+    names) that would otherwise be joined onto a base path unchecked.
+    """
+    if not name or '/' in name or '\\' in name or name in ('.', '..') or '\x00' in name:
+        return False
+    candidate = base_dir / name
+    return is_safe_path(base_dir, candidate) and candidate.is_dir()
 
 
 def get_laravel_docs_metadata(docs_path: Path, version: str) -> dict:
@@ -150,6 +217,10 @@ def list_laravel_docs_impl(docs_path: Path, version: Optional[str] = None, runti
     """
     logger.debug(f"list_laravel_docs_impl called (version: {version})")
 
+    version_error = validate_version(version)
+    if version_error:
+        return version_error
+
     try:
         if version:
             # List docs for specific version
@@ -178,9 +249,13 @@ def list_laravel_docs_impl(docs_path: Path, version: Optional[str] = None, runti
             versions_data: List[Dict] = []
             for v in SUPPORTED_VERSIONS:
                 version_path = docs_path / v
-                if version_path.exists() and any(f.endswith('.md') for f in os.listdir(version_path) if os.path.isfile(version_path / f)):
+                if not version_path.is_dir():
+                    continue
+                # Single scandir pass instead of two listdir calls plus a stat per file
+                with os.scandir(version_path) as entries:
+                    md_files = [e.name for e in entries if e.name.endswith('.md') and e.is_file()]
+                if md_files:
                     metadata = get_laravel_docs_metadata(docs_path, v)
-                    md_files = [f for f in os.listdir(version_path) if f.endswith('.md')]
                     versions_data.append({
                         "version": v,
                         "last_updated": metadata.get('sync_time', 'unknown'),
@@ -209,7 +284,11 @@ def read_laravel_doc_content_impl(docs_path: Path, filename: str, version: Optio
         version: Specific Laravel version to use. Overridden if filename includes version.
     """
     logger.debug(f"read_laravel_doc_content_impl called with filename: {filename}, version: {version}, runtime_version: {runtime_version}")
-    
+
+    version_error = validate_version(version)
+    if version_error:
+        return version_error
+
     # Extract version and relative path
     if '/' in filename and filename.split('/')[0] in SUPPORTED_VERSIONS:
         # Filename includes version
@@ -247,26 +326,33 @@ def read_laravel_doc_content_impl(docs_path: Path, filename: str, version: Optio
         return f"Error reading file: {str(e)}"
 
 
-def search_laravel_docs_impl(docs_path: Path, query: str, version: Optional[str] = None, include_external: bool = True, external_dir: Optional[Path] = None, runtime_version: Optional[str] = None) -> str:
+def search_laravel_docs_impl(docs_path: Path, query: str, version: Optional[str] = None, include_external: bool = True, external_dir: Optional[Path] = None, runtime_version: Optional[str] = None, all_versions: bool = False) -> str:
     """Search through Laravel documentation for a specific term.
 
     Args:
         docs_path: Base path for documentation
         query: Search term to look for
-        version: Specific Laravel version to search (e.g., "12.x"). If not provided, searches all versions.
+        version: Specific Laravel version to search (e.g., "12.x"). Defaults to the configured version.
         include_external: Whether to include external Laravel services documentation in search
         external_dir: Path to external documentation directory
+        all_versions: Search every supported version instead of just the configured one
 
     Returns:
         TOON-encoded structured search results.
     """
     logger.debug(f"search_laravel_docs_impl called with query: {query}, version: {version}, include_external: {include_external}")
 
+    version_error = validate_version(version)
+    if version_error:
+        return version_error
+
     if not query.strip():
         return format_error("Search query cannot be empty")
 
+    search_versions = resolve_search_versions(version, runtime_version, all_versions)
+
     # Check cache for search results
-    cache_key = f"search:{query}:{version}:{include_external}"
+    cache_key = f"search:{query}:{','.join(search_versions)}:{include_external}"
     with _cache_lock:
         if cache_key in _search_result_cache:
             logger.debug(f"Returning cached search results for: {query}")
@@ -278,8 +364,6 @@ def search_laravel_docs_impl(docs_path: Path, query: str, version: Optional[str]
 
     try:
         # Search core Laravel documentation
-        search_versions = [version] if version else SUPPORTED_VERSIONS
-
         for v in search_versions:
             version_path = docs_path / v
             if not version_path.exists():
@@ -291,8 +375,8 @@ def search_laravel_docs_impl(docs_path: Path, query: str, version: Optional[str]
 
                     content = get_file_content_cached(str(file_path))
                     if not content.startswith("Error") and not content.startswith("File not found"):
-                        if pattern.search(content):
-                            count = len(pattern.findall(content))
+                        count = count_matches(pattern, content)
+                        if count:
                             core_results_data.append({
                                 "file": f"{v}/{file}",
                                 "matches": count
@@ -308,8 +392,8 @@ def search_laravel_docs_impl(docs_path: Path, query: str, version: Optional[str]
                         try:
                             content = get_file_content_cached(str(file_path))
                             if not content.startswith("Error") and not content.startswith("File not found"):
-                                if pattern.search(content):
-                                    count = len(pattern.findall(content))
+                                count = count_matches(pattern, content)
+                                if count:
                                     external_results_data.append({
                                         "service": service_name,
                                         "file": file_path.name,
@@ -321,7 +405,7 @@ def search_laravel_docs_impl(docs_path: Path, query: str, version: Optional[str]
 
         # Format combined results
         if not core_results_data and not external_results_data:
-            search_scope = f"version {version}" if version else "all sources"
+            search_scope = f"version {version}" if version else f"versions {', '.join(search_versions)}"
             result = format_error(f"No results found for '{query}'", {"scope": search_scope})
         else:
             result = format_search_results(
@@ -334,9 +418,9 @@ def search_laravel_docs_impl(docs_path: Path, query: str, version: Optional[str]
         with _cache_lock:
             _search_result_cache[cache_key] = result
             # Limit cache size
-            if len(_search_result_cache) > 100:
+            if len(_search_result_cache) > _SEARCH_CACHE_MAX_ENTRIES:
                 # Remove oldest entries
-                oldest_keys = list(_search_result_cache.keys())[:20]
+                oldest_keys = list(_search_result_cache.keys())[:_SEARCH_CACHE_EVICT_COUNT]
                 for key in oldest_keys:
                     del _search_result_cache[key]
 
@@ -346,31 +430,37 @@ def search_laravel_docs_impl(docs_path: Path, query: str, version: Optional[str]
         return format_error(f"Error searching documentation: {str(e)}")
 
 
-def search_laravel_docs_with_context_impl(docs_path: Path, query: str, version: Optional[str] = None, 
+def search_laravel_docs_with_context_impl(docs_path: Path, query: str, version: Optional[str] = None,
                                          context_length: int = 200, include_external: bool = True,
-                                         external_dir: Optional[Path] = None, runtime_version: Optional[str] = None) -> str:
+                                         external_dir: Optional[Path] = None, runtime_version: Optional[str] = None,
+                                         all_versions: bool = False) -> str:
     """Search Laravel documentation and return matches with surrounding context.
-    
+
     Args:
         docs_path: Base path for documentation
         query: Search term to look for
-        version: Specific Laravel version to search. If not provided, searches all versions.
+        version: Specific Laravel version to search. Defaults to the configured version.
         context_length: Number of characters to show before/after match
         include_external: Whether to include external Laravel services documentation
         external_dir: Path to external documentation directory
+        all_versions: Search every supported version instead of just the configured one
     """
     logger.debug(f"search_laravel_docs_with_context_impl called with query: {query}")
-    
+
+    version_error = validate_version(version)
+    if version_error:
+        return version_error
+
     if not query.strip():
         return "Search query cannot be empty"
-    
+
     results = []
     pattern = re.compile(re.escape(query), re.IGNORECASE)
-    
+
     try:
         # Search core documentation
-        search_versions = [version] if version else SUPPORTED_VERSIONS
-        
+        search_versions = resolve_search_versions(version, runtime_version, all_versions)
+
         for v in search_versions:
             version_path = docs_path / v
             if not version_path.exists():
@@ -461,10 +551,15 @@ def get_doc_structure_impl(docs_path: Path, filename: str, version: Optional[str
     """
     logger.debug(f"get_doc_structure_impl called with filename: {filename}")
 
-    # Use read_laravel_doc_content_impl to get the content
-    content = read_laravel_doc_content_impl(docs_path, filename, version)
+    version_error = validate_version(version)
+    if version_error:
+        return version_error
 
-    if content.startswith("Error") or content.startswith("Documentation file not found") or content.startswith("Access denied"):
+    # Use read_laravel_doc_content_impl to get the content
+    content = read_laravel_doc_content_impl(docs_path, filename, version, runtime_version=runtime_version)
+
+    if (content.startswith("Error") or content.startswith("error:")
+            or content.startswith("Documentation file not found") or content.startswith("Access denied")):
         return content
 
     try:
@@ -503,6 +598,10 @@ def browse_docs_by_category_impl(docs_path: Path, category: str, version: Option
         TOON-encoded category documentation files with descriptions.
     """
     logger.debug(f"browse_docs_by_category_impl called with category: {category}, version: {version}, runtime_version: {runtime_version}")
+
+    version_error = validate_version(version)
+    if version_error:
+        return version_error
 
     if not version:
         version = runtime_version if runtime_version else DEFAULT_VERSION
@@ -575,6 +674,10 @@ def verify_laravel_feature_impl(docs_path: Path, feature: str, version: Optional
         TOON-encoded verification results with match status and matching files.
     """
     logger.debug(f"verify_laravel_feature_impl called with feature: {feature}, version: {version}")
+
+    version_error = validate_version(version)
+    if version_error:
+        return version_error
 
     # Validate inputs
     if not feature.strip():
@@ -728,6 +831,10 @@ def find_laravel_docs_for_need_impl(docs_path: Path, need: str, version: Optiona
     """
     logger.debug(f"find_laravel_docs_for_need_impl called with need: {need}")
 
+    version_error = validate_version(version)
+    if version_error:
+        return version_error
+
     if not need.strip():
         return format_error("Need description cannot be empty")
 
@@ -829,6 +936,10 @@ def get_laravel_content_by_difficulty_impl(docs_path: Path, difficulty: str, ver
         TOON-encoded list of documentation files at the specified difficulty level.
     """
     logger.debug(f"get_laravel_content_by_difficulty_impl called with difficulty: {difficulty}")
+
+    version_error = validate_version(version)
+    if version_error:
+        return version_error
 
     # Validate difficulty level
     try:
@@ -932,7 +1043,15 @@ def search_laravel_learning_resources_impl(
 
     # Determine which sources to search
     if sources:
-        search_dirs = [learning_dir / source for source in sources if (learning_dir / source).exists()]
+        invalid = [s for s in sources if not validate_subdirectory(learning_dir, s)]
+        if invalid:
+            available = sorted(d.name for d in learning_dir.iterdir() if d.is_dir())
+            logger.warning(f"Rejected invalid learning resource sources: {invalid}")
+            return format_error(
+                f"Invalid sources: {', '.join(invalid)}",
+                {"available_sources": available}
+            )
+        search_dirs = [learning_dir / source for source in sources]
     else:
         search_dirs = [d for d in learning_dir.iterdir() if d.is_dir()]
 
@@ -944,8 +1063,8 @@ def search_laravel_learning_resources_impl(
             try:
                 content = get_file_content_cached(str(file_path))
                 if not content.startswith("Error") and not content.startswith("File not found"):
-                    if pattern.search(content):
-                        count = len(pattern.findall(content))
+                    count = count_matches(pattern, content)
+                    if count:
                         source_matches.append({
                             "file": file_path.name,
                             "matches": count
@@ -991,13 +1110,14 @@ def list_laravel_learning_resources_impl(docs_path: Path, source: Optional[str] 
         )
 
     if source:
-        source_dir = learning_dir / source
-        if not source_dir.exists():
-            available_sources = [d.name for d in learning_dir.iterdir() if d.is_dir()]
+        if not validate_subdirectory(learning_dir, source):
+            available_sources = sorted(d.name for d in learning_dir.iterdir() if d.is_dir())
+            logger.warning(f"Rejected invalid learning resource source: {source!r}")
             return format_error(
                 f"Learning source '{source}' not found",
                 {"available_sources": available_sources}
             )
+        source_dir = learning_dir / source
 
         # List files in specific source
         files = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "laravel-mcp-companion"
-version = "0.9.0"
+version = "0.10.0"
 description = "A Laravel developer's MCP companion. Get the absolute best advice, recommendations, and up-to-date documentation for the entire Laravel ecosystem."
 authors = [{name = "Brian Irish", email = "irishb@gmail.com"}]
 readme = "README.md"

--- a/tests/unit/test_cache_management.py
+++ b/tests/unit/test_cache_management.py
@@ -3,7 +3,13 @@
 import threading
 from pathlib import Path
 from unittest.mock import patch, mock_open
-from mcp_tools import get_file_content_cached, search_laravel_docs_impl, clear_caches
+from mcp_tools import (
+    get_file_content_cached,
+    search_laravel_docs_impl,
+    clear_caches,
+    _FILE_CACHE_MAX_ENTRIES,
+    _FILE_CACHE_EVICT_COUNT,
+)
 
 
 class TestCacheManagement:
@@ -18,52 +24,56 @@ class TestCacheManagement:
         clear_caches()
     
     def test_file_cache_size_limit(self):
-        """Test that file cache respects 100-entry limit."""
+        """Test that the file cache evicts once it exceeds its entry limit."""
+        limit = _FILE_CACHE_MAX_ENTRIES
+        evicted = _FILE_CACHE_EVICT_COUNT
+
         # Mock file reading
         with patch('builtins.open', mock_open(read_data='content')):
-            # Fill cache with 100 entries
-            for i in range(100):
+            # Fill cache to exactly the limit
+            for i in range(limit):
                 content = get_file_content_cached(f'/path/file{i}.txt')
                 assert content == 'content'
-            
-            # Access cache to verify it has 100 entries
+
             from mcp_tools import _file_content_cache
-            assert len(_file_content_cache) == 100
-            
+            assert len(_file_content_cache) == limit
+
             # Add one more entry - should trigger cleanup
-            get_file_content_cached('/path/file100.txt')
-            
-            # Cache should now have 81 entries (100 - 20 + 1)
-            assert len(_file_content_cache) == 81
-            
-            # First 20 files should be removed
-            for i in range(20):
+            get_file_content_cached(f'/path/file{limit}.txt')
+
+            assert len(_file_content_cache) == limit - evicted + 1
+
+            # The oldest entries should be removed
+            for i in range(evicted):
                 assert f'/path/file{i}.txt' not in _file_content_cache
-            
-            # Files 20-99 should still be in cache
-            for i in range(20, 100):
+
+            # The rest should still be cached
+            for i in range(evicted, limit):
                 assert f'/path/file{i}.txt' in _file_content_cache
-            
+
             # The new file should be in cache
-            assert '/path/file100.txt' in _file_content_cache
-    
+            assert f'/path/file{limit}.txt' in _file_content_cache
+
     def test_file_cache_lru_eviction_order(self):
         """Test that oldest entries are removed first (FIFO behavior)."""
+        limit = _FILE_CACHE_MAX_ENTRIES
+        evicted = _FILE_CACHE_EVICT_COUNT
+
         with patch('builtins.open', mock_open(read_data='content')):
             # Fill cache with entries in a specific order
-            for i in range(100):
+            for i in range(limit):
                 get_file_content_cached(f'/path/ordered{i}.txt')
-            
+
             # Trigger eviction
             get_file_content_cached('/path/trigger.txt')
-            
+
             from mcp_tools import _file_content_cache
-            # Files 0-19 should be evicted (oldest)
-            for i in range(20):
+            # The oldest entries should be evicted first
+            for i in range(evicted):
                 assert f'/path/ordered{i}.txt' not in _file_content_cache
-            
-            # Files 20-99 should remain
-            for i in range(20, 100):
+
+            # Newer entries should remain
+            for i in range(evicted, limit):
                 assert f'/path/ordered{i}.txt' in _file_content_cache
     
     def test_search_cache_size_limit(self):
@@ -159,12 +169,10 @@ class TestCacheManagement:
         
         # Verify operations completed
         assert len(completed_operations) == 120
-        
-        # Check cache size is within limits
+
+        # Check cache size stays within its configured bound
         from mcp_tools import _file_content_cache
-        assert len(_file_content_cache) <= 100
-        # Should have evicted some entries
-        assert len(_file_content_cache) >= 80  # At least 80 after eviction
+        assert len(_file_content_cache) <= _FILE_CACHE_MAX_ENTRIES
     
     def test_cache_hit_behavior(self):
         """Test that cache hits don't affect eviction order."""
@@ -178,29 +186,33 @@ class TestCacheManagement:
             assert content1 == content2
             assert mock_file.call_count == 1  # No new file read
             
-            # Fill cache to near limit
-            for i in range(2, 101):
+            limit = _FILE_CACHE_MAX_ENTRIES
+            evicted = _FILE_CACHE_EVICT_COUNT
+
+            # Fill cache to exactly the limit (file1 is already entry 1)
+            for i in range(2, limit + 1):
                 get_file_content_cached(f'/path/file{i}.txt')
-            
+
             # Access first file again before eviction
             content3 = get_file_content_cached('/path/file1.txt')
             assert content3 == 'content'
-            
+
             # Trigger eviction
-            get_file_content_cached('/path/file101.txt')
-            
-            # The cache eviction removes the first 20 keys from the dict
-            # Since Python 3.7+, dicts maintain insertion order
+            get_file_content_cached(f'/path/file{limit + 1}.txt')
+
+            # Eviction removes the oldest keys from the dict.
+            # Since Python 3.7+, dicts maintain insertion order, and a cache hit
+            # does not refresh an entry's position.
             from mcp_tools import _file_content_cache
-            
-            # Files should be evicted in insertion order: file1.txt through file20.txt
-            for i in range(1, 21):
+
+            # Files are evicted in insertion order, starting with file1.txt
+            for i in range(1, evicted + 1):
                 assert f'/path/file{i}.txt' not in _file_content_cache, f"file{i}.txt should have been evicted"
-            
-            # Files 21-100 and 101 should still be in cache
-            for i in range(21, 101):
+
+            # The remainder, plus the newest entry, should still be cached
+            for i in range(evicted + 1, limit + 1):
                 assert f'/path/file{i}.txt' in _file_content_cache, f"file{i}.txt should still be in cache"
-            assert '/path/file101.txt' in _file_content_cache
+            assert f'/path/file{limit + 1}.txt' in _file_content_cache
     
     def test_cache_with_file_not_found(self):
         """Test cache behavior with file not found errors."""
@@ -232,21 +244,29 @@ class TestCacheManagement:
         assert '/path/bad_encoding.txt' not in _file_content_cache
     
     def test_search_cache_key_format(self):
-        """Test search cache key generation."""
+        """Cache keys record the versions actually searched, not the raw argument."""
+        from mcp_tools import resolve_search_versions
+
         with patch('mcp_tools.get_laravel_docs_metadata') as mock_metadata:
             mock_metadata.return_value = {}
-            
+
             # Test different parameter combinations
             search_laravel_docs_impl(Path("/fake/docs"), "test", version="11.x", include_external=True)
             search_laravel_docs_impl(Path("/fake/docs"), "test", version="11.x", include_external=False)
             search_laravel_docs_impl(Path("/fake/docs"), "test", version=None, include_external=True)
-            
+            search_laravel_docs_impl(Path("/fake/docs"), "test", version=None, include_external=True, all_versions=True)
+
             from mcp_tools import _search_result_cache
-            # Should have 3 different cache entries
-            assert len(_search_result_cache) == 3
+
+            default_scope = ','.join(resolve_search_versions(None))
+            all_scope = ','.join(resolve_search_versions(None, all_versions=True))
+
             assert "search:test:11.x:True" in _search_result_cache
             assert "search:test:11.x:False" in _search_result_cache
-            assert "search:test:None:True" in _search_result_cache
+            assert f"search:test:{default_scope}:True" in _search_result_cache
+            # Scoped and all-versions searches must not share a cache entry
+            assert f"search:test:{all_scope}:True" in _search_result_cache
+            assert default_scope != all_scope
     
     def test_clear_caches_function(self):
         """Test that clear_caches properly empties both caches."""

--- a/tests/unit/test_mcp_tool_functions.py
+++ b/tests/unit/test_mcp_tool_functions.py
@@ -399,12 +399,13 @@ class TestMcpToolsEdgeCases:
         assert "available_categories" in result.lower() or "frontend" in result.lower()
 
     def test_browse_docs_by_category_version_not_found(self, test_docs_dir):
-        """Test browsing docs when version doesn't exist."""
+        """Unsupported versions are rejected before touching the filesystem."""
         from mcp_tools import browse_docs_by_category_impl
 
         result = browse_docs_by_category_impl(test_docs_dir, "frontend", "99.x")
 
-        assert "No documentation found for version 99.x" in result
+        assert "Invalid version: 99.x" in result
+        assert "supported_versions" in result
 
     def test_browse_docs_by_category_no_matching_files(self, test_docs_dir):
         """Test browsing category with no matching files."""

--- a/tests/unit/test_path_traversal_security.py
+++ b/tests/unit/test_path_traversal_security.py
@@ -179,6 +179,11 @@ class TestSectionNameSanitization:
         "back\\slash",
         "nul\x00byte",
         "",
+        # Dot components: `base / "."` collapses to `base` itself
+        ".",
+        "./x",
+        "a/./b",
+        "a//b",
     ])
     def test_rejects_unsafe_section_names(self, bad):
         assert is_safe_section_name(bad) is False
@@ -197,10 +202,29 @@ class TestSectionNameSanitization:
 class TestDocsUpdaterVersionValidation:
     """DocsUpdater creates directories from `version` before any network call."""
 
-    @pytest.mark.parametrize("bad", ["../../pwned", "/tmp/pwned_abs", "..", "a/b"])
+    @pytest.mark.parametrize("bad", ["../../pwned", "/tmp/pwned_abs", "..", "a/b", ".", "./"])
     def test_rejects_traversal_version(self, tmp_path, bad):
         with pytest.raises(ValueError, match="Invalid Laravel version|escapes target"):
             DocsUpdater(tmp_path / "docs", bad)
+
+    def test_dot_version_cannot_target_the_docs_root(self, tmp_path):
+        """`docs_root / "."` collapses to docs_root, whose contents update() clears."""
+        docs = tmp_path / "docs"
+        (docs / "12.x").mkdir(parents=True)
+        (docs / "12.x" / "blade.md").write_text("important")
+
+        with pytest.raises(ValueError):
+            DocsUpdater(docs, ".")
+
+        # Every existing version must survive the rejected call
+        assert (docs / "12.x" / "blade.md").exists()
+
+    def test_version_dir_must_be_strict_subdirectory(self, tmp_path):
+        """A version resolving to the docs root itself is rejected."""
+        docs = tmp_path / "docs"
+        docs.mkdir(parents=True)
+        updater = DocsUpdater(docs, "12.x")
+        assert updater.version_dir.resolve() != docs.resolve()
 
     def test_creates_no_directories_when_rejected(self, tmp_path):
         target = tmp_path / "docs"
@@ -213,3 +237,55 @@ class TestDocsUpdaterVersionValidation:
         updater = DocsUpdater(tmp_path / "docs", "12.x")
         assert updater.version_dir == tmp_path / "docs" / "12.x"
         assert updater.version_dir.is_dir()
+
+
+class TestAllowlistArgumentParsing:
+    """CLI allowlists must replace the environment, not union with it.
+
+    argparse's "append" action appends to the default, so a non-empty default
+    would leave stale env entries trusted alongside the explicit CLI values.
+    """
+
+    def _parse(self, monkeypatch, argv, env):
+        import sys
+        from laravel_mcp_companion import parse_arguments
+
+        for var in ("CORS_ORIGINS", "ALLOWED_HOSTS"):
+            monkeypatch.delenv(var, raising=False)
+        for key, value in env.items():
+            monkeypatch.setenv(key, value)
+        monkeypatch.setattr(sys, "argv", ["prog"] + argv)
+        return parse_arguments()
+
+    def test_cli_origin_replaces_env(self, monkeypatch):
+        args = self._parse(
+            monkeypatch,
+            ["--cors-origin", "https://cli.example"],
+            {"CORS_ORIGINS": "https://env.example"},
+        )
+        assert args.cors_origin == ["https://cli.example"]
+
+    def test_cli_allowed_host_replaces_env(self, monkeypatch):
+        args = self._parse(
+            monkeypatch,
+            ["--allowed-host", "cli.example"],
+            {"ALLOWED_HOSTS": "env.example"},
+        )
+        assert args.allowed_host == ["cli.example"]
+
+    def test_env_used_when_flag_absent(self, monkeypatch):
+        args = self._parse(monkeypatch, [], {"CORS_ORIGINS": "https://env.example,https://two.example"})
+        assert args.cors_origin == ["https://env.example", "https://two.example"]
+
+    def test_repeated_flags_accumulate(self, monkeypatch):
+        args = self._parse(
+            monkeypatch,
+            ["--cors-origin", "https://a.example", "--cors-origin", "https://b.example"],
+            {},
+        )
+        assert args.cors_origin == ["https://a.example", "https://b.example"]
+
+    def test_defaults_are_empty(self, monkeypatch):
+        args = self._parse(monkeypatch, [], {})
+        assert args.cors_origin == []
+        assert args.allowed_host == []

--- a/tests/unit/test_path_traversal_security.py
+++ b/tests/unit/test_path_traversal_security.py
@@ -1,0 +1,215 @@
+"""Regression tests for path traversal and input validation.
+
+Each test here corresponds to a vulnerability that was exploitable before the
+security hardening pass. They assert that untrusted tool arguments cannot be
+used to read, enumerate, or write outside the documentation tree.
+"""
+
+import pytest
+
+from mcp_tools import (
+    is_safe_path,
+    validate_version,
+    validate_subdirectory,
+    read_laravel_doc_content_impl,
+    get_doc_structure_impl,
+    list_laravel_docs_impl,
+    verify_laravel_feature_impl,
+    browse_docs_by_category_impl,
+    search_laravel_docs_with_context_impl,
+    list_laravel_learning_resources_impl,
+    search_laravel_learning_resources_impl,
+)
+from docs_updater import is_safe_section_name, is_within_directory, DocsUpdater
+
+SECRET = "TOPSECRET-api-key-sk-live-1234"
+
+
+@pytest.fixture
+def docs_tree(tmp_path):
+    """A docs tree with secrets planted outside it."""
+    docs = tmp_path / "docs"
+    (docs / "12.x").mkdir(parents=True)
+    (docs / "12.x" / "blade.md").write_text("# Blade\n\nTemplating docs.")
+    (docs / "learning_resources" / "tutorials").mkdir(parents=True)
+    (docs / "learning_resources" / "tutorials" / "intro.md").write_text("# Intro")
+
+    # Secrets living outside the docs root
+    (tmp_path / "secret_notes.md").write_text(SECRET)
+    (tmp_path / "private").mkdir()
+    (tmp_path / "private" / "notes.md").write_text(SECRET)
+
+    # A sibling directory sharing a name prefix with a valid version
+    (docs / "12.x-backup").mkdir()
+    (docs / "12.x-backup" / "leak.md").write_text(SECRET)
+
+    return docs
+
+
+class TestVersionArgumentTraversal:
+    """The `version` argument is joined onto docs_path and must be allowlisted."""
+
+    @pytest.mark.parametrize("bad_version", ["..", "../..", "/etc", "/", "12.x/../..", "\x00"])
+    def test_read_doc_rejects_traversal_version(self, docs_tree, bad_version):
+        result = read_laravel_doc_content_impl(docs_tree, "secret_notes", version=bad_version)
+        assert SECRET not in result
+        assert "Invalid version" in result
+
+    def test_get_doc_structure_rejects_traversal_version(self, docs_tree):
+        result = get_doc_structure_impl(docs_tree, "secret_notes", version="..")
+        assert SECRET not in result
+        assert "Invalid version" in result
+
+    def test_list_docs_rejects_traversal_version(self, docs_tree):
+        result = list_laravel_docs_impl(docs_tree, version="..")
+        assert "secret_notes" not in result
+        assert "Invalid version" in result
+
+    def test_verify_feature_rejects_traversal_version(self, docs_tree):
+        result = verify_laravel_feature_impl(docs_tree, "secret_notes", version="..")
+        assert "secret_notes" not in result
+        assert "Invalid version" in result
+
+    def test_browse_category_rejects_traversal_version(self, docs_tree):
+        result = browse_docs_by_category_impl(docs_tree, "frontend", version="..")
+        assert SECRET not in result
+        assert "Invalid version" in result
+
+    def test_search_with_context_rejects_traversal_version(self, docs_tree):
+        result = search_laravel_docs_with_context_impl(
+            docs_tree, "TOPSECRET", version="..", include_external=False
+        )
+        assert SECRET not in result
+        assert "Invalid version" in result
+
+    def test_legitimate_version_still_works(self, docs_tree):
+        result = read_laravel_doc_content_impl(docs_tree, "blade.md", version="12.x")
+        assert "Templating docs." in result
+
+
+class TestFilenameTraversal:
+    """Traversal via the filename argument stays blocked."""
+
+    def test_filename_traversal_denied(self, docs_tree):
+        result = read_laravel_doc_content_impl(docs_tree, "../../secret_notes", version="12.x")
+        assert SECRET not in result
+        assert "Access denied" in result
+
+    def test_sibling_directory_prefix_not_treated_as_inside(self, docs_tree):
+        """A string-prefix check would wrongly accept '12.x-backup' under '12.x'."""
+        result = read_laravel_doc_content_impl(docs_tree, "../12.x-backup/leak", version="12.x")
+        assert SECRET not in result
+        assert "Access denied" in result
+
+
+class TestLearningResourceSources:
+    """`source`/`sources` name a subdirectory and must not escape it."""
+
+    def test_list_rejects_traversal_source(self, docs_tree):
+        result = list_laravel_learning_resources_impl(docs_tree, source="../../private")
+        assert "notes.md" not in result
+        assert "not found" in result
+
+    def test_search_rejects_traversal_source(self, docs_tree):
+        result = search_laravel_learning_resources_impl(
+            docs_tree, "TOPSECRET", sources=["../../private"]
+        )
+        assert "notes.md" not in result
+        assert "Invalid sources" in result
+
+    def test_legitimate_source_still_works(self, docs_tree):
+        result = list_laravel_learning_resources_impl(docs_tree, source="tutorials")
+        assert "intro.md" in result
+
+
+class TestIsSafePath:
+    def test_rejects_traversal(self, tmp_path):
+        base = tmp_path / "docs" / "12.x"
+        base.mkdir(parents=True)
+        assert is_safe_path(base, base / ".." / ".." / "secret.md") is False
+
+    def test_rejects_sibling_prefix_directory(self, tmp_path):
+        base = tmp_path / "docs" / "12.x"
+        base.mkdir(parents=True)
+        sibling = tmp_path / "docs" / "12.x-backup" / "leak.md"
+        assert is_safe_path(base, sibling) is False
+
+    def test_accepts_contained_path(self, tmp_path):
+        base = tmp_path / "docs" / "12.x"
+        base.mkdir(parents=True)
+        assert is_safe_path(base, base / "blade.md") is True
+
+    def test_fails_closed_on_error(self):
+        """Any resolution error denies access rather than raising."""
+        assert is_safe_path(None, None) is False
+
+
+class TestValidators:
+    def test_validate_version_accepts_supported(self):
+        from mcp_tools import SUPPORTED_VERSIONS
+        assert validate_version(SUPPORTED_VERSIONS[0]) is None
+
+    def test_validate_version_allows_none(self):
+        assert validate_version(None) is None
+
+    @pytest.mark.parametrize("bad", ["..", "/etc", "99.x", "12.x/..", "'; DROP TABLE"])
+    def test_validate_version_rejects_bad(self, bad):
+        result = validate_version(bad)
+        assert result is not None
+        assert "Invalid version" in result
+
+    def test_validate_subdirectory(self, tmp_path):
+        (tmp_path / "real").mkdir()
+        assert validate_subdirectory(tmp_path, "real") is True
+        assert validate_subdirectory(tmp_path, "..") is False
+        assert validate_subdirectory(tmp_path, "../etc") is False
+        assert validate_subdirectory(tmp_path, "/etc") is False
+        assert validate_subdirectory(tmp_path, "") is False
+        assert validate_subdirectory(tmp_path, "nonexistent") is False
+
+
+class TestSectionNameSanitization:
+    """Section names are parsed from remote HTML and become file paths."""
+
+    @pytest.mark.parametrize("bad", [
+        "../../../../etc/passwd",
+        "/absolute/path",
+        "..",
+        "a/../../b",
+        "back\\slash",
+        "nul\x00byte",
+        "",
+    ])
+    def test_rejects_unsafe_section_names(self, bad):
+        assert is_safe_section_name(bad) is False
+
+    @pytest.mark.parametrize("good", ["eloquent", "getting-started", "api/reference", "v2.0_notes"])
+    def test_accepts_safe_section_names(self, good):
+        assert is_safe_section_name(good) is True
+
+    def test_is_within_directory(self, tmp_path):
+        base = tmp_path / "external" / "forge"
+        base.mkdir(parents=True)
+        assert is_within_directory(base, base / "intro.md") is True
+        assert is_within_directory(base, base / ".." / ".." / "evil.md") is False
+
+
+class TestDocsUpdaterVersionValidation:
+    """DocsUpdater creates directories from `version` before any network call."""
+
+    @pytest.mark.parametrize("bad", ["../../pwned", "/tmp/pwned_abs", "..", "a/b"])
+    def test_rejects_traversal_version(self, tmp_path, bad):
+        with pytest.raises(ValueError, match="Invalid Laravel version|escapes target"):
+            DocsUpdater(tmp_path / "docs", bad)
+
+    def test_creates_no_directories_when_rejected(self, tmp_path):
+        target = tmp_path / "docs"
+        with pytest.raises(ValueError):
+            DocsUpdater(target, "../../pwned")
+        assert not (tmp_path.parent / "pwned").exists()
+        assert not (tmp_path / "pwned").exists()
+
+    def test_accepts_valid_version(self, tmp_path):
+        updater = DocsUpdater(tmp_path / "docs", "12.x")
+        assert updater.version_dir == tmp_path / "docs" / "12.x"
+        assert updater.version_dir.is_dir()


### PR DESCRIPTION
Fixes four HIGH and three MEDIUM severity security issues found in a full-codebase audit, plus the performance problems found alongside them. Every vulnerability was confirmed with a working exploit before the fix and re-tested after.

## Security

**Arbitrary `.md` file read via the `version` argument (HIGH).** `version` was joined onto `docs_path` without validation, and `is_safe_path` derived its base from that *same* tainted value — so the containment check moved in lockstep with the attack and could never fail. `version=".."` read any `.md` file on the host; `version="/etc"` reached absolute paths. The same argument gave directory enumeration and a content oracle through `list_laravel_docs`, `verify_laravel_feature`, `browse_docs_by_category`, and `search_laravel_docs_with_context`. Reachable in the default `search` transform mode through the `call_tool` proxy, so hiding the raw tools did not mitigate it.

**Two separately-broken `is_safe_path` implementations (HIGH).** The server module's copy used `Path.absolute()`, which does not resolve `..`, making the parent check purely lexical — it returned `True` for paths resolving outside the base, leaving the `laravel://` and `laravel-external://` resource templates open to percent-encoded traversal (`..%2F..%2F`). The `mcp_tools` copy used a string prefix check that treated `12.x-backup` as living under `12.x`. Both are replaced by one `resolve()` + `is_relative_to()` helper that fails closed.

**HTTP transport was unauthenticated, network-bound, and reflectively CORS'd (HIGH).** `mcp.http_app()` was called with no arguments, so FastMCP's `HostOriginGuardMiddleware` (off by default upstream) was never installed — no Host validation, no Origin validation, no auth, bound to `0.0.0.0`. Meanwhile `allow_origins=["*"]` with `allow_credentials=True` makes Starlette *reflect* the requesting Origin with `Access-Control-Allow-Credentials: true` (verified in `starlette/middleware/cors.py:166-168`), and `expose_headers` handed a malicious page the `mcp-session-id` it needed to finish the handshake. This is what turned the traversal above into a remote read primitive.

**Arbitrary `.md` overwrite from a hostile upstream (HIGH).** Section names are regex-scraped from remote documentation HTML and used raw as `target_dir / f"{section}.md"`. Both `../` and absolute values escaped the target directory, so whoever controls an upstream doc site (compromise, malicious mirror, TLS-MITM) could overwrite any `.md` file with content they serve — including `CLAUDE.md`, i.e. persistent prompt injection.

Also fixed: unguarded learning-resource `source`/`sources` (file enumeration + substring oracle), and unvalidated `version` in `DocsUpdater.__init__` creating directory trees outside the docs root before any network call.

### Verification

All exploits confirmed blocked, with legitimate access unaffected:

| Attack | Before | After |
|---|---|---|
| `read_laravel_doc_content(version="..")` | leaked secret file | `Invalid version` |
| Resource template `laravel://12.x/..%2F..%2Fsecret` | leaked secret file | denied |
| Cross-origin preflight from `https://evil.example` | `200` + reflected origin + credentials | `403 Forbidden Origin` |
| Cross-origin `initialize` | `200`, full handshake | `403` |
| DNS-rebinding `Host: attacker.com` | `200` | `421 Misdirected Request` |
| Section name `../../../../evil` | wrote outside target dir | skipped |
| Legitimate local client / `12.x/blade.md` | worked | still works |

Adds 47 regression tests (`tests/unit/test_path_traversal_security.py`).

## Performance

- **Startup**: version list now reads its cache first with a 24h TTL instead of always calling the GitHub API at import; all nine `urlopen` calls got timeouts (none had one, so a stalled connection hung startup indefinitely).
- **Stale-content bug**: `update_laravel_docs` only cleared the server module's caches, not the `mcp_tools` caches the read/search tools actually use — docs stayed stale until restart.
- **Search**: defaults to the configured version instead of scanning all 8 (`all_versions=true` opts back in); file cache resized so a search stops evicting its own corpus; match counting is one pass instead of `search()` + `findall()`.
- **Updates**: fetch the latest commit once per update instead of three times (unauthenticated GitHub limit is 60/hour).
- **Ranking bug**: `score += int(0.5)` added zero, so package name/description matches never affected recommendations.

## Test plan

- [x] 501 tests pass (up from 454); coverage 68.31% → 68.84%
- [x] `ruff` and `mypy` clean
- [x] MCP Inspector smoke test passes
- [x] Every exploit re-run against patched code (table above)
- [x] HTTP transport verified end-to-end with `curl`: attacks blocked, legitimate handshake succeeds

## Breaking changes

- **HTTP mode binds `127.0.0.1`** instead of `0.0.0.0`. Docker is unaffected (`HOST=0.0.0.0` set in the Dockerfile); bare-metal users exposing the port need `--host 0.0.0.0 --allowed-host <name>`.
- **CORS is off unless configured** via `--cors-origin`. Browser clients need explicit origins; wildcards are rejected.
- **`search_laravel_docs` defaults to one version.** Pass `all_versions=true` for the old behavior.
- Unsupported `version` values now return `Invalid version` instead of `No documentation found`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTTP configuration options for host binding, CORS origins, and allowed hosts.
  * Added support for searching Laravel documentation across all available versions.
  * HTTP mode now defaults to localhost and applies stricter host and origin protections.

* **Bug Fixes**
  * Improved protection against unsafe paths, directory traversal, and invalid versions.
  * Added request timeouts and more reliable documentation version caching.
  * Improved cache management and search performance.

* **Documentation**
  * Expanded Docker and HTTP security guidance, including reverse-proxy recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->