### PR TITLE
Remove broken Harness cache config that masked CI failures

### DIFF
--- a/.harness/orgs/default/projects/laravel_mcp_companion/pipelines/ci.yaml
+++ b/.harness/orgs/default/projects/laravel_mcp_companion/pipelines/ci.yaml
@@ -16,10 +16,14 @@ pipeline:
         type: CI
         spec:
           cloneCodebase: true
-          caching:
-            enabled: true
-            paths:
-              - .venv
+          # Caching is intentionally disabled. The previous config cached `.venv`,
+          # which this pipeline never creates (dependencies are installed with a
+          # plain `pip install`), and supplied no cache key, which the cache plugin
+          # requires whenever custom paths are used. Both cache steps therefore
+          # failed on every run and left the stage permanently IGNORE_FAILED,
+          # masking the status of the steps that actually matter.
+          # To reinstate caching, point it at a directory the pipeline populates
+          # (e.g. ~/.cache/pip) with a key derived from requirements*.txt.
           platform:
             os: Linux
             arch: Amd64


### PR DESCRIPTION
The Harness `Test` stage has been reporting a degraded status on every run because its two cache steps always fail. Removing the cache config fixes it.

## What's broken

From the run on #375:

```
Restore Cache: "A key must be provided if any custom paths are used. Skipping cache"
               file not found: ciH-yETASgajriAIm02SgQ/default/.venv
Save Cache:    build cache, source <.venv>, make sure file or directory exists
               and readable, lstat .venv: no such file or directory
```

Two independent problems in the same three lines of config:

1. **`.venv` is never created.** The pipeline installs dependencies with a plain `pip install -r requirements.txt` at system level — no virtualenv is ever made. So Save Cache has nothing to archive and Restore has nothing to fetch.
2. **No cache key.** The plugin requires one whenever custom `paths` are used, and none was supplied, so it refuses the request outright.

## Why it matters beyond the noise

Because both steps fail every run, the stage sits permanently at `IGNORE_FAILED` and posts `success` to GitHub no matter what the real steps did. **The `ci-test` status can't distinguish a green build from a broken one.**

That is not hypothetical — it actively misled this work. While reviewing #375 I saw `IGNORE_FAILED`, correctly concluded the status was untrustworthy, and had no way to tell whether the masked failure was cache noise or a real regression in the PR. It took pulling the raw Harness logs to find out. Next time the masked failure may be the test step.

Related: `main` has been posting outright `failure` for `ci-test` since `a41efda` — four consecutive commits — for the same underlying reason.

## The fix

Delete the `caching:` block. `Install Dependencies` takes ~17s, so there is little to reclaim, and a cache that has never once worked is not worth repairing on spec. The comment left in its place records what the correct form would be (a real path like `~/.cache/pip`, plus a key derived from `requirements*.txt`) if anyone wants it back.

## Test plan

- [x] YAML parses; all five real steps (`Install Dependencies`, `Lint with ruff`, `Type check with mypy`, `Run tests`, `MCP Inspector smoke test`) are unchanged
- [x] Those steps already pass — verified locally: ruff clean, mypy clean across 34 files, `pytest --cov --cov-branch --cov-report=xml --junitxml=results.xml` exits 0, Inspector smoke test greps successfully
- [ ] Confirm on the first run after merge that the stage reports `SUCCESS` rather than `IGNORE_FAILED`

Note that `.harness/**` changes only take effect once merged: branch builds resolve the pipeline definition from `main`, so this PR's own CI run will still show the old behavior.

## Still outstanding

This removes the *cause* of the masked failures, but not the masking mechanism. There is no `failureStrategies` block in the repo's YAML, so the ignore-failure behavior is configured in the Harness UI. Worth confirming it is scoped to the cache steps rather than the whole stage — if it is stage-wide, a genuine test failure would still be swallowed after this merge. Tracked in the CI issue alongside the coverage-measurement problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI pipeline execution settings by disabling ineffective caching.
  * Added guidance for configuring caching correctly if it is reintroduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->