### PR TITLE
Stop docs syncs consuming semver, and measure coverage honestly

### DIFF
--- a/.harness/orgs/default/projects/laravel_mcp_companion/pipelines/ci.yaml
+++ b/.harness/orgs/default/projects/laravel_mcp_companion/pipelines/ci.yaml
@@ -37,32 +37,48 @@ pipeline:
                   name: Install Dependencies
                   type: Run
                   spec:
-                    shell: Sh
+                    shell: Bash
                     command: |
-                      python -m pip install --upgrade pip
-                      pip install -r requirements.txt
-                      pip install -r requirements-dev.txt
+                      set -euo pipefail
+
+                      # The runner image ships Python 3.10, but this project
+                      # declares requires-python = ">=3.12" (see also
+                      # .python-version and the package classifiers). CI was
+                      # therefore testing an interpreter the project does not
+                      # claim to support. Install the declared version rather
+                      # than inheriting whatever the image happens to provide.
+                      curl -LsSf https://astral.sh/uv/install.sh | sh
+                      export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+
+                      uv python install 3.12
+                      uv venv --python 3.12 .venv
+                      uv pip install --python .venv/bin/python \
+                        -r requirements.txt -r requirements-dev.txt
+
+                      # Later steps run in fresh shells, so they invoke the
+                      # interpreter by path rather than activating the venv.
+                      .venv/bin/python --version
               - step:
                   identifier: lint
                   name: Lint with ruff
                   type: Run
                   spec:
                     shell: Sh
-                    command: ruff check .
+                    command: .venv/bin/ruff check .
               - step:
                   identifier: typecheck
                   name: Type check with mypy
                   type: Run
                   spec:
                     shell: Sh
-                    command: mypy --ignore-missing-imports .
+                    command: .venv/bin/mypy --ignore-missing-imports .
               - step:
                   identifier: test
                   name: Run tests
                   type: Run
                   spec:
                     shell: Sh
-                    command: pytest --cov --cov-branch --cov-report=xml --junitxml=results.xml
+                    command: .venv/bin/pytest --cov --cov-branch --cov-report=xml --junitxml=results.xml
                     reports:
                       type: JUnit
                       spec:
@@ -81,6 +97,7 @@ pipeline:
                       eval "$(fnm env)"
                       fnm install 22
                       fnm use 22
-                      # Inspector 2.0 requires the server command before --method
-                      npx @modelcontextprotocol/inspector@2 --cli python laravel_mcp_companion.py --method tools/list | grep -q "search_laravel_docs"
+                      # Inspector 2.0 requires the server command before --method.
+                      # Use the project venv, not the image's default interpreter.
+                      npx @modelcontextprotocol/inspector@2 --cli .venv/bin/python laravel_mcp_companion.py --method tools/list | grep -q "search_laravel_docs"
 

--- a/.harness/orgs/default/projects/laravel_mcp_companion/pipelines/docs_update.yaml
+++ b/.harness/orgs/default/projects/laravel_mcp_companion/pipelines/docs_update.yaml
@@ -278,34 +278,43 @@ pipeline:
                       git fetch origin
                       git checkout <+execution.steps.wait_for_merge.output.outputVariables.MERGE_COMMIT>
               - step:
-                  identifier: create_tag_and_release
-                  name: Create tag and release
+                  identifier: create_docs_tag
+                  name: Create docs tag
                   type: Run
                   spec:
                     shell: Bash
                     envVariables:
                       GH_TOKEN: <+secrets.getValue("PAT_FOR_WORKFLOWS")>
                     command: |
+                      set -euo pipefail
+
+                      # Documentation syncs are tagged by date, not by semantic
+                      # version. They previously incremented the patch number on
+                      # every run, so ~145 consecutive releases were content
+                      # refreshes and the version number tracked days elapsed
+                      # rather than anything about the software. Each one also
+                      # published a GitHub Release marked --latest, which pushed
+                      # real releases off the repository front page.
+                      #
+                      # NOTE: the release pipeline builds Docker images from tag
+                      # pushes, so its trigger must match BOTH "v*" and "docs-*".
+                      # If docs images stop publishing, check that trigger first.
                       git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/brianirish/laravel-mcp-companion.git"
 
-                      # Get the latest tag, default to v0.0.0 if no tags exist
-                      LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
-                      echo "Latest tag: $LATEST_TAG"
+                      TAG="docs-$(date -u +%Y-%m-%d)"
 
-                      # Extract version numbers
-                      VERSION=${LATEST_TAG#v}
-                      IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+                      # A second sync on the same day would collide; fall back to
+                      # a minute-precision tag rather than failing the pipeline.
+                      git fetch --tags --quiet origin
+                      if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+                        TAG="docs-$(date -u +%Y-%m-%d-%H%M)"
+                        echo "Daily tag already exists, using ${TAG}"
+                      fi
 
-                      # Increment patch version for docs updates
-                      NEW_PATCH=$((PATCH + 1))
-                      NEW_VERSION="v${MAJOR}.${MINOR}.${NEW_PATCH}"
+                      echo "Creating docs tag: ${TAG}"
+                      git tag "$TAG"
+                      git push origin "$TAG"
 
-                      echo "Creating new tag: $NEW_VERSION"
-                      git tag "$NEW_VERSION"
-                      git push origin "$NEW_VERSION"
-
-                      echo "Creating GitHub release: $NEW_VERSION"
-                      gh release create "$NEW_VERSION" \
-                        --title "$NEW_VERSION" \
-                        --notes "Documentation Update - Updated Laravel and external services documentation to latest version" \
-                        --latest
+                      # Intentionally no `gh release create` here. Docs syncs are
+                      # not releases; the tag exists to identify the snapshot and
+                      # to trigger the Docker image build.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,82 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
+this project follows [Semantic Versioning](https://semver.org). While on `0.x` the
+public API is not yet stable, so **breaking changes ship in minor releases** and are
+always called out below.
+
+Releases before v0.10.0 predate this file; see the
+[GitHub releases page](https://github.com/brianirish/laravel-mcp-companion/releases)
+for their notes. Documentation-sync snapshots are tagged `docs-YYYY-MM-DD` and are
+not releases — they do not appear here.
+
+## [Unreleased]
+
+### Changed
+- Documentation syncs are tagged `docs-YYYY-MM-DD` instead of incrementing the
+  patch version, and no longer publish a GitHub Release. Version numbers now
+  describe the software rather than counting days of content refreshes.
+- Coverage is measured against the product modules only, with branch coverage
+  enabled in one place, so a bare `pytest` and CI report the same figure. The
+  previous CI invocation also measured the test suite, inflating the reported
+  number well above actual product coverage.
+
+### Fixed
+- Removed a Harness cache configuration that failed on every run — it cached a
+  `.venv` the pipeline never creates and supplied no cache key — leaving the
+  test stage permanently degraded and masking the status of the steps that
+  matter.
+
+### Added
+- Tests asserting the project version stays consistent across `pyproject.toml`,
+  `ROADMAP.md`, and `README.md`, and that pytest and coverage are configured in
+  exactly one place each.
+
+## [0.10.0] - 2026-07-30
+
+### Breaking
+- `tools/list` now returns a search-first surface (`search_tools`, `call_tool`,
+  plus a pinned `search_laravel_docs`) rather than all 26 tools. Use
+  `--transform-mode none` to restore the previous listing.
+- The HTTP transport binds `127.0.0.1` instead of `0.0.0.0`, validates `Host`
+  and `Origin` headers, and sends no CORS headers unless `--cors-origin` is
+  given. Docker is unaffected. Non-loopback binds now require `--allowed-host`.
+- Documentation search covers the configured Laravel version rather than all
+  supported versions; pass `all_versions: true` for the previous behavior.
+- Unsupported `version` arguments are rejected with an explicit error instead of
+  falling through to a filesystem lookup.
+
+### Security
+- Fixed arbitrary `.md` file read via an unvalidated `version` argument, which
+  was joined onto the documentation path while the containment check derived its
+  base from that same untrusted value.
+- Replaced two independently broken path containment checks — one using
+  `Path.absolute()`, which does not resolve `..`, and one using a string prefix
+  comparison that treated `12.x-backup` as inside `12.x`.
+- Fixed unauthenticated network exposure: wildcard CORS origins combined with
+  credentials caused arbitrary origins to be reflected back as trusted.
+- Fixed arbitrary `.md` overwrite from a hostile upstream, where section names
+  scraped from remote HTML were used directly as file paths.
+- Validated learning-resource `source` parameters and updater versions that
+  previously allowed directory enumeration and out-of-tree directory creation.
+
+### Added
+- `--transform-mode {search,code,none}` selecting the tool exposure strategy,
+  including experimental Code Mode with sandboxed Python execution.
+- `--cors-origin` and `--allowed-host` for explicit HTTP allowlists.
+
+### Fixed
+- Documentation is no longer served stale after an update; the update tools
+  cleared only one of two caches.
+- Package recommendations now account for name and description matches, which a
+  scoring expression had been discarding.
+
+### Changed
+- FastMCP floor raised to 3.4.5 and Starlette to 1.3.1.
+- Startup reads the supported-version list from cache with a 24-hour TTL, and
+  all network calls have timeouts.
+
+[Unreleased]: https://github.com/brianirish/laravel-mcp-companion/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/brianirish/laravel-mcp-companion/compare/v0.9.145...v0.10.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,40 +31,30 @@ Issues = "https://github.com/brianirish/laravel-mcp-companion/issues"
 # Broader adoption (UP/SIM/BLE/etc.) should be its own PR.
 select = ["E4", "E7", "E9", "F"]
 
-[tool.pytest.ini_options]
-minversion = "6.0"
-addopts = [
-    "-ra",
-    "--strict-markers",
-    "--strict-config",
-    "--cov=laravel_mcp_companion",
-    "--cov=docs_updater", 
-    "--cov=shutdown_handler",
-    "--cov=mcp_tools",
-    "--cov-report=term-missing",
-    "--cov-report=html:htmlcov",
-    "--cov-report=xml:coverage.xml"
+# pytest configuration lives in pytest.ini, which takes precedence over this
+# file. A [tool.pytest.ini_options] block here would be silently ignored, so
+# it is deliberately absent -- the previous one had drifted to a stale, shorter
+# module list that nothing was reading.
+
+[tool.coverage.run]
+# Branch coverage is on here rather than passed on the command line, so a bare
+# `pytest` and CI's `pytest --cov --cov-branch` report the identical number.
+branch = true
+# Measure the product modules only. Without this, CI's bare `--cov` also
+# measured the test suite, whose near-total coverage inflated the number well
+# past the threshold while product coverage sat much lower.
+source = [
+    "laravel_mcp_companion",
+    "docs_updater",
+    "shutdown_handler",
+    "toon_helpers",
+    "mcp_tools",
+    "learning_resources",
 ]
-testpaths = ["tests"]
-python_files = ["test_*.py"]
-python_classes = ["Test*"]
-python_functions = ["test_*"]
-markers = [
-    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
-    "integration: marks tests as integration tests",
-    "unit: marks tests as unit tests",
-    "network: marks tests that require network access",
-    "external: marks tests that interact with external services"
+omit = [
+    "tests/*",
+    "*/site-packages/*",
 ]
-filterwarnings = [
-    "ignore::DeprecationWarning",
-    "ignore::PendingDeprecationWarning"
-]
-log_cli = true
-log_cli_level = "INFO"
-log_cli_format = "%(asctime)s [%(levelname)8s] %(name)s: %(message)s"
-log_cli_date_format = "%Y-%m-%d %H:%M:%S"
-asyncio_mode = "auto"
 
 [dependency-groups]
 dev = [

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,16 +5,17 @@ addopts =
     -ra
     --strict-markers
     --strict-config
-    --cov=laravel_mcp_companion
-    --cov=docs_updater
-    --cov=shutdown_handler
-    --cov=toon_helpers
-    --cov=mcp_tools
-    --cov=learning_resources
+;   Which files are measured is defined once in pyproject.toml under
+;   [tool.coverage.run]; listing modules here as well let the two configs drift.
+    --cov
     --cov-report=term-missing
     --cov-report=html:htmlcov
     --cov-report=xml:coverage.xml
-    --cov-fail-under=80
+;   This is a ratchet, not a target. It sits just below current coverage so the
+;   gate catches regressions; raise it as coverage improves. The old value of 80
+;   never passed against the product modules -- it only appeared to pass in CI,
+;   which was also counting the test suite.
+    --cov-fail-under=65
 testpaths = tests
 python_files = test_*.py
 python_classes = Test*

--- a/tests/unit/test_version_consistency.py
+++ b/tests/unit/test_version_consistency.py
@@ -1,0 +1,81 @@
+"""Guard against the project version drifting between the files that record it.
+
+`pyproject.toml` sat at 0.9.0 while release tags had reached v0.9.145, because
+nothing asserted the two agreed. The documentation-sync pipeline no longer
+touches version numbers, so they now change only when someone bumps them
+deliberately -- these tests make sure that bump reaches every file.
+"""
+
+import re
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def project_version() -> str:
+    with open(REPO_ROOT / "pyproject.toml", "rb") as f:
+        return tomllib.load(f)["project"]["version"]
+
+
+def test_pyproject_version_is_valid_semver():
+    version = project_version()
+    assert re.fullmatch(r"\d+\.\d+\.\d+", version), f"Not a semver version: {version!r}"
+
+
+def test_roadmap_current_version_matches_pyproject():
+    roadmap = (REPO_ROOT / "ROADMAP.md").read_text()
+    match = re.search(r"^## Current Version:\s*v(\S+)", roadmap, re.MULTILINE)
+    assert match, "ROADMAP.md is missing a '## Current Version: vX.Y.Z' line"
+    assert match.group(1) == project_version(), (
+        f"ROADMAP.md says v{match.group(1)} but pyproject.toml says {project_version()}"
+    )
+
+
+def test_readme_features_heading_matches_pyproject():
+    readme = (REPO_ROOT / "README.md").read_text()
+    match = re.search(r"^## Features \(v(\S+?)\)", readme, re.MULTILINE)
+    assert match, "README.md is missing a '## Features (vX.Y.Z)' heading"
+    assert match.group(1) == project_version(), (
+        f"README.md says v{match.group(1)} but pyproject.toml says {project_version()}"
+    )
+
+
+def test_pytest_is_configured_in_exactly_one_place():
+    """Only pytest.ini configures pytest; a second source silently drifts.
+
+    pyproject.toml previously carried a [tool.pytest.ini_options] table that
+    pytest ignored (pytest.ini wins) and that had drifted to a shorter module
+    list than the one actually in force.
+    """
+    with open(REPO_ROOT / "pyproject.toml", "rb") as f:
+        config = tomllib.load(f)
+
+    assert "ini_options" not in config.get("tool", {}).get("pytest", {}), (
+        "pyproject.toml must not configure pytest; pytest.ini takes precedence "
+        "and the two will drift"
+    )
+    assert "[pytest]" in (REPO_ROOT / "pytest.ini").read_text()
+
+
+def test_coverage_measures_product_code_not_tests():
+    """A bare --cov must not count the test suite.
+
+    CI ran `pytest --cov`, which measured everything including tests/. Their
+    near-total coverage inflated the reported figure past the gate while
+    product coverage was far lower.
+    """
+    with open(REPO_ROOT / "pyproject.toml", "rb") as f:
+        config = tomllib.load(f)
+
+    run_config = config.get("tool", {}).get("coverage", {}).get("run", {})
+    assert run_config, "pyproject.toml is missing [tool.coverage.run]"
+
+    source = run_config.get("source", [])
+    assert source, "[tool.coverage.run] must pin the measured source modules"
+    assert "tests" not in source
+
+    omit = run_config.get("omit", [])
+    assert any("tests" in pattern for pattern in omit), (
+        "[tool.coverage.run] omit must exclude the test suite"
+    )

--- a/tests/unit/test_version_consistency.py
+++ b/tests/unit/test_version_consistency.py
@@ -4,18 +4,40 @@
 nothing asserted the two agreed. The documentation-sync pipeline no longer
 touches version numbers, so they now change only when someone bumps them
 deliberately -- these tests make sure that bump reaches every file.
+
+These assertions are made against the configuration files as text rather than
+through a TOML parser, so they run identically on any interpreter. `tomllib` is
+standard library only from 3.11, and depending on it here would couple this
+suite to whichever Python the CI runner happens to ship.
 """
 
 import re
-import tomllib
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
+def read(filename: str) -> str:
+    return (REPO_ROOT / filename).read_text(encoding="utf-8")
+
+
+def toml_table(content: str, table: str) -> str | None:
+    """Return the raw body of a TOML table, or None when it is absent.
+
+    Only table headers at the start of a line count, so a table name mentioned
+    inside a comment is not treated as a declaration.
+    """
+    pattern = rf"^\[{re.escape(table)}\]$(.*?)(?=^\[|\Z)"
+    match = re.search(pattern, content, re.MULTILINE | re.DOTALL)
+    return match.group(1) if match else None
+
+
 def project_version() -> str:
-    with open(REPO_ROOT / "pyproject.toml", "rb") as f:
-        return tomllib.load(f)["project"]["version"]
+    table = toml_table(read("pyproject.toml"), "project")
+    assert table is not None, "pyproject.toml has no [project] table"
+    match = re.search(r'^version\s*=\s*"([^"]+)"', table, re.MULTILINE)
+    assert match, "pyproject.toml [project] has no version"
+    return match.group(1)
 
 
 def test_pyproject_version_is_valid_semver():
@@ -24,8 +46,7 @@ def test_pyproject_version_is_valid_semver():
 
 
 def test_roadmap_current_version_matches_pyproject():
-    roadmap = (REPO_ROOT / "ROADMAP.md").read_text()
-    match = re.search(r"^## Current Version:\s*v(\S+)", roadmap, re.MULTILINE)
+    match = re.search(r"^## Current Version:\s*v(\S+)", read("ROADMAP.md"), re.MULTILINE)
     assert match, "ROADMAP.md is missing a '## Current Version: vX.Y.Z' line"
     assert match.group(1) == project_version(), (
         f"ROADMAP.md says v{match.group(1)} but pyproject.toml says {project_version()}"
@@ -33,8 +54,7 @@ def test_roadmap_current_version_matches_pyproject():
 
 
 def test_readme_features_heading_matches_pyproject():
-    readme = (REPO_ROOT / "README.md").read_text()
-    match = re.search(r"^## Features \(v(\S+?)\)", readme, re.MULTILINE)
+    match = re.search(r"^## Features \(v(\S+?)\)", read("README.md"), re.MULTILINE)
     assert match, "README.md is missing a '## Features (vX.Y.Z)' heading"
     assert match.group(1) == project_version(), (
         f"README.md says v{match.group(1)} but pyproject.toml says {project_version()}"
@@ -48,14 +68,11 @@ def test_pytest_is_configured_in_exactly_one_place():
     pytest ignored (pytest.ini wins) and that had drifted to a shorter module
     list than the one actually in force.
     """
-    with open(REPO_ROOT / "pyproject.toml", "rb") as f:
-        config = tomllib.load(f)
-
-    assert "ini_options" not in config.get("tool", {}).get("pytest", {}), (
+    assert toml_table(read("pyproject.toml"), "tool.pytest.ini_options") is None, (
         "pyproject.toml must not configure pytest; pytest.ini takes precedence "
         "and the two will drift"
     )
-    assert "[pytest]" in (REPO_ROOT / "pytest.ini").read_text()
+    assert "[pytest]" in read("pytest.ini")
 
 
 def test_coverage_measures_product_code_not_tests():
@@ -65,17 +82,28 @@ def test_coverage_measures_product_code_not_tests():
     near-total coverage inflated the reported figure past the gate while
     product coverage was far lower.
     """
-    with open(REPO_ROOT / "pyproject.toml", "rb") as f:
-        config = tomllib.load(f)
+    table = toml_table(read("pyproject.toml"), "tool.coverage.run")
+    assert table is not None, "pyproject.toml is missing [tool.coverage.run]"
 
-    run_config = config.get("tool", {}).get("coverage", {}).get("run", {})
-    assert run_config, "pyproject.toml is missing [tool.coverage.run]"
+    source_match = re.search(r"^source\s*=\s*\[(.*?)\]", table, re.MULTILINE | re.DOTALL)
+    assert source_match, "[tool.coverage.run] must pin the measured source modules"
+    source = source_match.group(1)
+    assert "laravel_mcp_companion" in source
+    assert '"tests"' not in source
 
-    source = run_config.get("source", [])
-    assert source, "[tool.coverage.run] must pin the measured source modules"
-    assert "tests" not in source
-
-    omit = run_config.get("omit", [])
-    assert any("tests" in pattern for pattern in omit), (
+    omit_match = re.search(r"^omit\s*=\s*\[(.*?)\]", table, re.MULTILINE | re.DOTALL)
+    assert omit_match, "[tool.coverage.run] must declare an omit list"
+    assert "tests" in omit_match.group(1), (
         "[tool.coverage.run] omit must exclude the test suite"
     )
+
+
+def test_coverage_gate_is_configured():
+    """The gate must exist and sit at or below current coverage.
+
+    An unreachable threshold is worse than none: it fails every run, which
+    trains everyone to ignore the result.
+    """
+    match = re.search(r"--cov-fail-under=(\d+)", read("pytest.ini"))
+    assert match, "pytest.ini must set --cov-fail-under"
+    assert 0 < int(match.group(1)) <= 100


### PR DESCRIPTION
Closes #376. Closes the coverage half of #378 — the failure-masking half is discussed at the bottom and is **not** fixed here.

## Versioning (#376)

Documentation syncs incremented the patch number on every run, so ~145 consecutive releases were content refreshes and the version number tracked *days elapsed* rather than anything about the software. Each sync also published a GitHub Release marked `--latest`, which would have pushed the v0.10.0 security release off the repository front page on the very next run.

Docs syncs now tag `docs-YYYY-MM-DD` and create **no** GitHub Release:

```
docs sync  → tag docs-2026-07-30   (no GitHub Release)
           → docker :latest + :docs-2026-07-30

real rel.  → tag v0.11.0           (GitHub Release, --latest)
           → docker :latest + :v0.11.0
```

Same-day re-runs fall back to a minute-precision tag (`docs-2026-07-30-1155`) rather than failing the pipeline. Both forms are valid Docker tags — verified.

### ⚠️ Required Harness change

The release pipeline builds images from tag pushes (`<+trigger.tag>`), so **its trigger must now match `docs-*` in addition to `v*`.** Without that, documentation updates stop producing refreshed Docker images — docs are baked in via `COPY . .`, so `:latest` would go stale.

This can't be done from the repo (the trigger lives in the Harness UI), so it's called out in a comment on the step itself for whoever debugs it later.

## Coverage (#378, part 2)

Two configurations were measuring different things against one threshold:

| invocation | measured | result |
|---|---|---|
| `pytest` (pytest.ini) | 6 product modules | **68.85%** — failed the 80% gate |
| `pytest --cov --cov-branch` (CI) | everything, **including `tests/`** | **81.73%** — passed |

CI only cleared the bar because it counted the test suite, whose near-total coverage did the lifting. The number that passed was substantially measuring test code.

Now the measured set lives once in `[tool.coverage.run]`, with branch coverage enabled there rather than on the command line, so both invocations agree exactly:

```
bare  pytest                        → 65.91%, exit 0
pytest --cov --cov-branch (CI)      → 65.91%, exit 0
```

`--cov-fail-under` drops to 65 — just under actual coverage, so the gate catches regressions instead of failing unconditionally. **It's a ratchet to raise over time, not a target that was ever being met.** 65.91% is the honest figure; 81.73% never was.

Also removes the dead `[tool.pytest.ini_options]` table from `pyproject.toml`. `pytest.ini` takes precedence, so it was never read — and it had drifted to a 4-module list versus the 6 actually in force.

## Guards against recurrence

`pyproject.toml` sat at `0.9.0` while tags reached `v0.9.145` because nothing checked. New tests assert the version agrees across `pyproject.toml`, `ROADMAP.md`, and `README.md`, and that pytest and coverage are each configured in exactly one place. Verified they actually fail on a partial bump, rather than just passing today.

## CHANGELOG

Added, starting at v0.10.0 and pointing at the GitHub releases page for earlier versions rather than reconstructing history I can't verify. `docs-*` snapshots are explicitly excluded as non-releases.

## Test plan

- [x] 519 tests pass (was 514); ruff and mypy clean
- [x] Both coverage invocations produce identical numbers and exit 0
- [x] Drift guards fail when `pyproject.toml` is bumped without `ROADMAP.md`/`README.md`
- [x] Tag logic dry-run, including same-day collision; both forms are valid Docker tags
- [x] `docs_update.yaml` parses; all 12 steps intact
- [ ] First docs-sync run after merge produces a `docs-*` tag and a Docker image (needs the trigger update above)

## Not fixed here: the masked-failure half of #378

`ci-test` still reports `success` while the stage comes back `IGNORE_FAILED`, and #377 did **not** clear it — the cache-fix branch build (`8c91ab0`) came back `SUCCEEDED`, but the merge commit on main (`ac5e9d6`) went back to `IGNORE_FAILED` with byte-identical pipeline YAML. So something other than the cache steps is failing and being swallowed, and the ignore-failure strategy lives in the Harness UI where it can't be audited from the repo. Needs someone to open that execution and see which step is red. Tracked in #378.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documentation updates now use date-based tags, avoiding duplicate tags and preventing unnecessary release creation.
  - Added release notes covering security improvements, CLI options, documentation search behavior, caching, recommendations, and runtime updates.

- **Quality Improvements**
  - Improved version consistency checks across project documentation.
  - Refined coverage measurement to focus on product code and provide more reliable reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->