### PR TITLE
Mirror Harness triggers into the repo

### DIFF
--- a/.harness/orgs/default/projects/laravel_mcp_companion/triggers/README.md
+++ b/.harness/orgs/default/projects/laravel_mcp_companion/triggers/README.md
@@ -1,0 +1,54 @@
+# Harness triggers
+
+**These files are a mirror, not the source of truth.** Harness stores triggers in
+its own database, not in this repository — unlike the pipelines and input sets
+alongside them, which are Remote (git-backed) and are read from here. Editing a
+file in this directory changes nothing in Harness; edits have to be made in the
+UI, then copied back here.
+
+They are checked in anyway because triggers are load-bearing and were previously
+invisible to review. A UI edit on 2026-07-30 stopped the release pipeline firing
+for `v*` tags, which silently broke Docker image publishing: tag `v0.10.1` was
+created but no image was ever built, leaving `:latest` stale. There was no pull
+request, no diff, and nothing to restore from. A mirror gives us something to
+diff against and to rebuild from.
+
+## Mirrored here
+
+| Trigger | Pipeline | Fires on |
+|---------|----------|----------|
+| `ci-push-trigger.yaml` | `ci` | Every push, any branch |
+
+## Not yet mirrored
+
+- **Release trigger** (`release` pipeline) — paste its YAML here when convenient.
+- **Docs update cron** (`docs_update` pipeline) — scheduled, feeds `docs_update_cron_input_set`.
+
+## What the release trigger must satisfy
+
+Recorded here because it is currently misconfigured and this is the requirement
+it has to meet, independent of the exact YAML:
+
+- It feeds `release_tag_input_set`, which builds `type: tag` from `<+trigger.tag>`,
+  so it must be a tag-ref trigger.
+- It must match **both** tag families:
+  - `v*` — software releases, which publish a Docker image and a GitHub Release
+  - `docs-*` — documentation snapshots, which publish a Docker image only
+- Matching only one family breaks the other. Matching only `docs-*` means version
+  releases publish no image; matching only `v*` means documentation updates never
+  reach `:latest`, which is the state that motivated this note.
+
+After changing it, verify a tag of each kind produces an image:
+
+```bash
+gh api "user/packages/container/laravel-mcp-companion/versions?per_page=10" \
+  --jq '.[] | "\(.created_at)  \(.metadata.container.tags | join(", "))"'
+```
+
+## Keeping this honest
+
+A mirror that drifts is worse than none. Options, in rough order of preference:
+
+1. Move triggers to Git-backed storage if this Harness version supports it, which
+   removes the mirror problem entirely.
+2. Re-copy the YAML here in the same change that edits a trigger in the UI.

--- a/.harness/orgs/default/projects/laravel_mcp_companion/triggers/ci-push-trigger.yaml
+++ b/.harness/orgs/default/projects/laravel_mcp_companion/triggers/ci-push-trigger.yaml
@@ -1,0 +1,26 @@
+trigger:
+  name: ci-push-trigger
+  identifier: ci_push_trigger
+  enabled: true
+  encryptedWebhookSecretIdentifier: ""
+  description: Trigger CI on every push to any branch
+  tags: {}
+  orgIdentifier: default
+  stagesToExecute: []
+  projectIdentifier: laravel_mcp_companion
+  pipelineIdentifier: ci
+  source:
+    type: Webhook
+    spec:
+      type: Github
+      spec:
+        type: Push
+        spec:
+          connectorRef: Laravel_MCP_Companion
+          autoAbortPreviousExecutions: false
+          payloadConditions: []
+          headerConditions: []
+          actions: []
+  pipelineBranchName: <+trigger.branch>
+  inputSetRefs:
+    - ci_push_input_set


### PR DESCRIPTION
Harness stores triggers in its own database, not in this repository. The pipelines and input sets under `.harness/` are Remote (git-backed) and genuinely read from here — triggers are not, which made them the one piece of load-bearing CI config invisible to review.

That blind spot has already cost us. A UI edit on 2026-07-30 stopped the release pipeline firing for `v*` tags, so tag `v0.10.1` was created but **no Docker image was ever built** and `:latest` has been stale since. No pull request, no diff, nothing to restore from — it surfaced only because I queried the container registry directly while writing README instructions:

```
2026-07-30T03:22:14Z  v0.10.0, latest   ← newest image
2026-07-31T00:09:31Z  v0.10.1 tag created, no image
```

## What this adds

- `triggers/ci-push-trigger.yaml` — the CI push trigger, verbatim
- `triggers/README.md` — states plainly that these are a mirror rather than the source of truth, lists what is and isn't mirrored yet, and records the requirement the release trigger must meet

**These files change nothing in Harness.** Editing them has no effect; edits still have to be made in the UI and copied back. They exist so the config can be diffed and rebuilt.

## The release trigger requirement, written down

Recorded in the README because it is currently misconfigured and the requirement holds regardless of the exact YAML:

- It feeds `release_tag_input_set`, which builds `type: tag` from `<+trigger.tag>`, so it must be a tag-ref trigger.
- It must match **both** `v*` (software releases → image + GitHub Release) and `docs-*` (documentation snapshots → image only).
- Matching only one family breaks the other. Matching only `docs-*` means version releases publish no image; matching only `v*` means documentation updates never reach `:latest`. The latter is the state that motivated this.

The README includes the `gh api` one-liner to verify a tag of each kind actually produces an image.

## Follow-up

The release trigger and docs-update cron aren't mirrored here — I only have the CI trigger's YAML, and I'd rather leave gaps than check in a reconstruction someone might apply verbatim. Paste those two and I'll add them.

Longer term the real fix is Git-backed triggers if this Harness version supports them, which removes the mirror-drift problem entirely. Noted in the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an enabled CI pipeline trigger for GitHub push events across all branches.
  - Configured the trigger to use the CI input set without automatically canceling previous runs.

- **Documentation**
  - Documented trigger synchronization practices and source-of-truth guidance.
  - Added details for release and documentation tag triggers, release requirements, and package verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->