### PR TITLE
Tell the assistant how old the documentation is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ docs-only commit and contains no code change.
   stage permanently degraded and masking the status of the steps that matter.
 
 ### Added
+- The server now reports how old its documentation snapshot is. MCP server
+  instructions carry the snapshot date for the version being served, so an
+  assistant asked about a feature newer than that snapshot says so and offers to
+  refresh rather than answering from stale pages. `laravel_docs_info` reports
+  `snapshot_date` and `snapshot_age_days`, and flags snapshots older than 30 days.
 - Tests asserting the project version matches the newest release tag, and stays
   consistent across `pyproject.toml`, `ROADMAP.md`, and `README.md`. The tag
   comparison is the one that matters: during the drift that motivated these

--- a/README.md
+++ b/README.md
@@ -108,6 +108,42 @@ docker run --rm -i ghcr.io/brianirish/laravel-mcp-companion:latest --force-updat
 | `--cors-origin ORIGIN` | Browser origin allowed to call the HTTP transport, repeatable (env: `CORS_ORIGINS`) | none (CORS off) |
 | `--allowed-host HOST` | Additional `Host` header accepted in HTTP mode, repeatable (env: `ALLOWED_HOSTS`) | `localhost`, `127.0.0.1`, `::1` |
 
+### Keeping documentation current
+
+Documentation ships inside the image and is refreshed daily, so `:latest` always
+contains the newest snapshot. The catch is that **`docker run` reuses the copy you
+already have** — once you've pulled the image, you keep running it until you pull
+again. Refresh whenever you like:
+
+```bash
+docker pull ghcr.io/brianirish/laravel-mcp-companion:latest
+```
+
+Or add `--pull=always` to your MCP config so every start checks for a newer image.
+It costs a moment of startup time and needs a working connection, so it's opt-in
+rather than the default:
+
+```jsonc
+"args": ["run", "--rm", "-i", "--pull=always",
+         "ghcr.io/brianirish/laravel-mcp-companion:latest"]
+```
+
+You don't have to track this yourself. The server tells your assistant how old its
+documentation is, so if you ask about something newer than the snapshot it will say
+so and offer to refresh instead of answering from stale pages. You can also just
+ask — *"how current are your Laravel docs?"* — which runs `laravel_docs_info`.
+
+To update in place without pulling a new image, `--update-docs` fetches the newest
+core Laravel documentation during startup. Documentation for Forge, Vapor, Nova,
+Envoyer and community packages refreshes separately, through the
+`update_external_laravel_docs` tool your assistant can call. With `--rm` the
+download is discarded when the container exits, so mount a volume to keep it:
+
+```bash
+docker run --rm -i -v laravel-mcp-docs:/app/docs \
+  ghcr.io/brianirish/laravel-mcp-companion:latest --update-docs
+```
+
 ### Transform Modes
 
 By default the server no longer lists all of its tools. Instead it exposes a compact, search-first interface that keeps your AI client's context window lean:

--- a/README.md
+++ b/README.md
@@ -110,10 +110,11 @@ docker run --rm -i ghcr.io/brianirish/laravel-mcp-companion:latest --force-updat
 
 ### Keeping documentation current
 
-Documentation ships inside the image and is refreshed daily, so `:latest` always
-contains the newest snapshot. The catch is that **`docker run` reuses the copy you
-already have** — once you've pulled the image, you keep running it until you pull
-again. Refresh whenever you like:
+Documentation ships inside the image, and a new image is published whenever the
+documentation is refreshed, so `:latest` carries the most recently published
+snapshot. The catch is that **`docker run` reuses the copy you already have** —
+once you've pulled the image, you keep running it until you pull again. Refresh
+whenever you like:
 
 ```bash
 docker pull ghcr.io/brianirish/laravel-mcp-companion:latest
@@ -128,21 +129,29 @@ rather than the default:
          "ghcr.io/brianirish/laravel-mcp-companion:latest"]
 ```
 
-You don't have to track this yourself. The server tells your assistant how old its
-documentation is, so if you ask about something newer than the snapshot it will say
-so and offer to refresh instead of answering from stale pages. You can also just
-ask — *"how current are your Laravel docs?"* — which runs `laravel_docs_info`.
+You don't have to track this yourself. The server tells your assistant how old the
+documentation is for the Laravel version it's serving, so if you ask about something
+newer than that snapshot it will say so and offer to refresh instead of answering
+from stale pages. You can also just ask — *"how current are your Laravel docs?"*
 
-To update in place without pulling a new image, `--update-docs` fetches the newest
-core Laravel documentation during startup. Documentation for Forge, Vapor, Nova,
-Envoyer and community packages refreshes separately, through the
-`update_external_laravel_docs` tool your assistant can call. With `--rm` the
-download is discarded when the container exits, so mount a volume to keep it:
+To update in place without pulling a new image, `--update-docs` fetches fresh
+documentation for the selected Laravel version during startup. Documentation for
+Forge, Vapor, Nova, Envoyer and community packages refreshes separately, through the
+`update_external_laravel_docs` tool your assistant can call.
+
+With `--rm` the download is discarded when the container exits, so it repeats on
+every start. A named volume keeps it — but note the trade-off:
 
 ```bash
 docker run --rm -i -v laravel-mcp-docs:/app/docs \
   ghcr.io/brianirish/laravel-mcp-companion:latest --update-docs
 ```
+
+> **A volume overrides the image's documentation.** Once populated it masks
+> `/app/docs`, so pulling a newer image no longer updates what the server reads —
+> the volume becomes your source of truth and `--update-docs` becomes the way you
+> refresh it. Use a volume when you want to control updates explicitly; stick to
+> plain `docker pull` if you'd rather the image stay in charge.
 
 ### Transform Modes
 

--- a/laravel_mcp_companion.py
+++ b/laravel_mcp_companion.py
@@ -1133,35 +1133,66 @@ def laravel_docs_info(version: Optional[str] = None) -> str:
     return "This function requires server context to execute"
 
 
-def build_server_instructions(docs_path: Path, runtime_version: str) -> str:
+def build_server_instructions(
+    docs_path: Path,
+    runtime_version: str,
+    transform_mode: Optional[str] = "search",
+) -> str:
     """Compose the instructions an MCP client injects into the model's context.
 
     This is where the assistant learns how old the bundled documentation is.
     Without it, a stale snapshot produces confidently wrong answers about recent
     Laravel features, because nothing in the tool output says how old the corpus
     is and the user has no reason to suspect it.
+
+    The freshness reported is that of `runtime_version`, the version this server
+    actually answers from. Reporting the newest version present would describe a
+    corpus the user is not reading -- an older pinned version can be months
+    behind while another sits at today's date.
+
+    The described workflow follows `transform_mode`, because the search and code
+    transforms replace the individual tools with a small synthetic surface.
+    Naming hidden tools would invite calls the client cannot route.
     """
-    freshness = describe_docs_freshness(docs_path)
+    freshness = describe_docs_freshness(docs_path, runtime_version)
 
-    instructions = f"""Laravel documentation for the whole ecosystem: core Laravel {', '.join(SUPPORTED_VERSIONS)}, \
-the first-party services (Forge, Vapor, Nova, Envoyer), and community packages \
-(Spatie, Livewire, Filament, Inertia).
-
-Typical flow: search_laravel_docs to locate relevant files, then \
+    if transform_mode == "search":
+        workflow = """Tools are exposed through a search interface rather than listed \
+individually. Call search_tools with a natural-language description to find the right \
+tool, then invoke it through call_tool with its name and arguments. \
+search_laravel_docs is also available directly."""
+        refresh = ('call_tool with "update_laravel_docs" (or '
+                   '"update_external_laravel_docs" for the first-party services and '
+                   'package documentation)')
+        info_tool = 'call_tool with "laravel_docs_info"'
+    elif transform_mode == "code":
+        workflow = """Tools are exposed through Code Mode. Use tags and search to \
+discover them, get_schema for their parameters, and execute to run Python that calls \
+them."""
+        refresh = "the update_laravel_docs tool (or update_external_laravel_docs)"
+        info_tool = "the laravel_docs_info tool"
+    else:
+        workflow = """Typical flow: search_laravel_docs to locate relevant files, then \
 read_laravel_doc_content for the full text. For a natural-language request such as \
 "I need to upload files", find_laravel_docs_for_need maps it to the right pages. \
-get_laravel_package_recommendations suggests packages for a described use case.
+get_laravel_package_recommendations suggests packages for a described use case."""
+        refresh = ("update_laravel_docs (or update_external_laravel_docs for the "
+                   "first-party services and package documentation)")
+        info_tool = "laravel_docs_info"
 
-Documentation defaults to Laravel {runtime_version}; pass `version` to target another, \
-or `all_versions` to search every one.
+    return f"""Laravel documentation for the whole ecosystem: core Laravel \
+{', '.join(SUPPORTED_VERSIONS)}, the first-party services (Forge, Vapor, Nova, \
+Envoyer), and community packages (Spatie, Livewire, Filament, Inertia).
 
-The documentation is a local snapshot, last synced {freshness}. If you are asked \
-about a feature that may have landed after that date, say so rather than answering \
-from the snapshot, and offer to run update_laravel_docs (or \
-update_external_laravel_docs for the first-party services and package docs) to \
-refresh it first. laravel_docs_info reports the current snapshot date at any time."""
+{workflow}
 
-    return instructions
+Documentation answers default to Laravel {runtime_version}; pass `version` to target \
+another, or `all_versions` to search every one.
+
+The Laravel {runtime_version} documentation is a local snapshot, last synced \
+{freshness}. If you are asked about a feature that may have landed after that date, \
+say so rather than answering from the snapshot, and offer to refresh it first using \
+{refresh}. {info_tool} reports the current snapshot date at any time."""
 
 
 def validate_version(version: str) -> bool:
@@ -1294,7 +1325,10 @@ def create_mcp_server(server_name: str, docs_path: Path, runtime_version: str, t
     }
     
     # Create the MCP server
-    mcp: FastMCP = FastMCP(server_name, instructions=build_server_instructions(docs_path, runtime_version))
+    mcp: FastMCP = FastMCP(
+        server_name,
+        instructions=build_server_instructions(docs_path, runtime_version, transform_mode)
+    )
     
     # Initialize multi-source documentation updater
     multi_updater = MultiSourceDocsUpdater(docs_path, runtime_version)
@@ -1526,7 +1560,7 @@ def configure_mcp_server(mcp: FastMCP, docs_path: Path, runtime_version: str, mu
                 "commit_message": metadata.get('commit_message', 'unknown'),
                 "github_url": metadata.get('commit_url', 'unknown')
             }
-            if docs_are_stale(docs_path, version):
+            if docs_are_stale(docs_path, version, age_days=age_days):
                 info["note"] = (
                     f"This snapshot is more than {DOCS_STALE_AFTER_DAYS} days old. "
                     "Run update_laravel_docs() before relying on it for recent features."
@@ -1539,9 +1573,11 @@ def configure_mcp_server(mcp: FastMCP, docs_path: Path, runtime_version: str, mu
             for v in SUPPORTED_VERSIONS:
                 metadata = get_laravel_docs_metadata(docs_path, v)
                 if "version" in metadata:
+                    _, v_age = get_docs_snapshot_age(docs_path, v)
                     versions_data.append({
                         "version": v,
                         "last_updated": metadata.get('sync_time', 'unknown'),
+                        "age_days": v_age if v_age is not None else "unknown",
                         "commit": metadata.get('commit_sha', 'unknown')[:7] if metadata.get('commit_sha') else 'unknown',
                         "commit_date": metadata.get('commit_date', 'unknown'),
                         "available": True
@@ -1552,16 +1588,21 @@ def configure_mcp_server(mcp: FastMCP, docs_path: Path, runtime_version: str, mu
                         "available": False
                     })
 
-            snapshot, age_days = get_docs_snapshot_age(docs_path)
+            # Across versions this reports the OLDEST snapshot. The per-version
+            # rows carry the detail; a headline quoting the freshest version
+            # would imply the whole corpus is current when most of it is not.
+            oldest_date, oldest_age = get_docs_snapshot_age(docs_path)
             summary: Dict[str, Any] = {
-                "snapshot_date": snapshot or "unknown",
-                "snapshot_age_days": age_days if age_days is not None else "unknown",
+                "oldest_snapshot_date": oldest_date or "unknown",
+                "oldest_snapshot_age_days": oldest_age if oldest_age is not None else "unknown",
+                "default_version": runtime_version,
                 "versions": versions_data
             }
-            if docs_are_stale(docs_path):
+            if docs_are_stale(docs_path, age_days=oldest_age):
                 summary["note"] = (
-                    f"This snapshot is more than {DOCS_STALE_AFTER_DAYS} days old. "
-                    "Run update_laravel_docs() before relying on it for recent features."
+                    f"At least one version's documentation is more than {DOCS_STALE_AFTER_DAYS} "
+                    "days old. Check the per-version rows and run update_laravel_docs() for any "
+                    "version you intend to rely on."
                 )
             return toon_encode(summary)
     

--- a/laravel_mcp_companion.py
+++ b/laravel_mcp_companion.py
@@ -51,7 +51,11 @@ from mcp_tools import (
     is_safe_path,
     validate_version as validate_version_arg,
     count_matches,
-    clear_caches as clear_mcp_tools_caches
+    clear_caches as clear_mcp_tools_caches,
+    describe_docs_freshness,
+    get_docs_snapshot_age,
+    docs_are_stale,
+    DOCS_STALE_AFTER_DAYS
 )
 
 # Import learning resources
@@ -1129,6 +1133,37 @@ def laravel_docs_info(version: Optional[str] = None) -> str:
     return "This function requires server context to execute"
 
 
+def build_server_instructions(docs_path: Path, runtime_version: str) -> str:
+    """Compose the instructions an MCP client injects into the model's context.
+
+    This is where the assistant learns how old the bundled documentation is.
+    Without it, a stale snapshot produces confidently wrong answers about recent
+    Laravel features, because nothing in the tool output says how old the corpus
+    is and the user has no reason to suspect it.
+    """
+    freshness = describe_docs_freshness(docs_path)
+
+    instructions = f"""Laravel documentation for the whole ecosystem: core Laravel {', '.join(SUPPORTED_VERSIONS)}, \
+the first-party services (Forge, Vapor, Nova, Envoyer), and community packages \
+(Spatie, Livewire, Filament, Inertia).
+
+Typical flow: search_laravel_docs to locate relevant files, then \
+read_laravel_doc_content for the full text. For a natural-language request such as \
+"I need to upload files", find_laravel_docs_for_need maps it to the right pages. \
+get_laravel_package_recommendations suggests packages for a described use case.
+
+Documentation defaults to Laravel {runtime_version}; pass `version` to target another, \
+or `all_versions` to search every one.
+
+The documentation is a local snapshot, last synced {freshness}. If you are asked \
+about a feature that may have landed after that date, say so rather than answering \
+from the snapshot, and offer to run update_laravel_docs (or \
+update_external_laravel_docs for the first-party services and package docs) to \
+refresh it first. laravel_docs_info reports the current snapshot date at any time."""
+
+    return instructions
+
+
 def validate_version(version: str) -> bool:
     """Validate that the version is supported.
     
@@ -1259,7 +1294,7 @@ def create_mcp_server(server_name: str, docs_path: Path, runtime_version: str, t
     }
     
     # Create the MCP server
-    mcp: FastMCP = FastMCP(server_name)
+    mcp: FastMCP = FastMCP(server_name, instructions=build_server_instructions(docs_path, runtime_version))
     
     # Initialize multi-source documentation updater
     multi_updater = MultiSourceDocsUpdater(docs_path, runtime_version)
@@ -1480,14 +1515,23 @@ def configure_mcp_server(mcp: FastMCP, docs_path: Path, runtime_version: str, mu
                     {"suggestion": "Use update_laravel_docs() to fetch documentation"}
                 )
 
-            return toon_encode({
+            snapshot, age_days = get_docs_snapshot_age(docs_path, version)
+            info: Dict[str, Any] = {
                 "version": version,
                 "last_updated": metadata.get('sync_time', 'unknown'),
+                "snapshot_date": snapshot or "unknown",
+                "snapshot_age_days": age_days if age_days is not None else "unknown",
                 "commit_sha": metadata.get('commit_sha', 'unknown'),
                 "commit_date": metadata.get('commit_date', 'unknown'),
                 "commit_message": metadata.get('commit_message', 'unknown'),
                 "github_url": metadata.get('commit_url', 'unknown')
-            })
+            }
+            if docs_are_stale(docs_path, version):
+                info["note"] = (
+                    f"This snapshot is more than {DOCS_STALE_AFTER_DAYS} days old. "
+                    "Run update_laravel_docs() before relying on it for recent features."
+                )
+            return toon_encode(info)
         else:
             # Show info for all available versions
             versions_data: List[Dict[str, Any]] = []
@@ -1508,7 +1552,18 @@ def configure_mcp_server(mcp: FastMCP, docs_path: Path, runtime_version: str, mu
                         "available": False
                     })
 
-            return toon_encode({"versions": versions_data})
+            snapshot, age_days = get_docs_snapshot_age(docs_path)
+            summary: Dict[str, Any] = {
+                "snapshot_date": snapshot or "unknown",
+                "snapshot_age_days": age_days if age_days is not None else "unknown",
+                "versions": versions_data
+            }
+            if docs_are_stale(docs_path):
+                summary["note"] = (
+                    f"This snapshot is more than {DOCS_STALE_AFTER_DAYS} days old. "
+                    "Run update_laravel_docs() before relying on it for recent features."
+                )
+            return toon_encode(summary)
     
     # Register package recommendation tools
     @mcp.tool(

--- a/mcp_tools.py
+++ b/mcp_tools.py
@@ -9,6 +9,7 @@ that can be imported and tested independently of the FastMCP server setup.
 import os
 import re
 import logging
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional
 import json
@@ -184,6 +185,66 @@ def validate_subdirectory(base_dir: Path, name: str) -> bool:
         return False
     candidate = base_dir / name
     return is_safe_path(base_dir, candidate) and candidate.is_dir()
+
+
+# Documentation is shipped as a snapshot, so it ages. Past this many days we
+# start saying so out loud rather than letting the assistant answer from a stale
+# corpus without realising it.
+DOCS_STALE_AFTER_DAYS = 30
+
+
+def parse_sync_time(value: Optional[str]) -> Optional[datetime]:
+    """Parse a metadata sync_time into an aware UTC datetime, or None."""
+    if not value or value == "unknown":
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def get_docs_snapshot_age(docs_path: Path, version: Optional[str] = None) -> tuple[Optional[str], Optional[int]]:
+    """Return (sync_time, age_in_days) for the freshest documentation snapshot.
+
+    Checks the requested version, or every supported version when none is given,
+    and reports the most recent sync. Returns (None, None) when no metadata is
+    readable, which is the normal case for a fresh checkout.
+    """
+    # Callers reach this through server construction, where docs_path may still
+    # be a plain string; joining one would raise rather than report "unknown".
+    base = Path(docs_path)
+    versions = [version] if version else SUPPORTED_VERSIONS
+    newest: Optional[datetime] = None
+
+    for candidate in versions:
+        synced = parse_sync_time(get_laravel_docs_metadata(base, candidate).get("sync_time"))
+        if synced and (newest is None or synced > newest):
+            newest = synced
+
+    if newest is None:
+        return None, None
+
+    age = (datetime.now(timezone.utc) - newest).days
+    return newest.strftime("%Y-%m-%d"), max(age, 0)
+
+
+def describe_docs_freshness(docs_path: Path, version: Optional[str] = None) -> str:
+    """Human-readable snapshot age, for tool output and server instructions."""
+    snapshot, age = get_docs_snapshot_age(docs_path, version)
+    if snapshot is None:
+        return "unknown (no documentation synced yet)"
+    if age == 0:
+        return f"{snapshot} (today)"
+    return f"{snapshot} ({age} day{'s' if age != 1 else ''} ago)"
+
+
+def docs_are_stale(docs_path: Path, version: Optional[str] = None) -> bool:
+    """Whether the snapshot is old enough to be worth mentioning."""
+    _, age = get_docs_snapshot_age(docs_path, version)
+    return age is not None and age > DOCS_STALE_AFTER_DAYS
 
 
 def get_laravel_docs_metadata(docs_path: Path, version: str) -> dict:

--- a/mcp_tools.py
+++ b/mcp_tools.py
@@ -193,9 +193,14 @@ def validate_subdirectory(base_dir: Path, name: str) -> bool:
 DOCS_STALE_AFTER_DAYS = 30
 
 
-def parse_sync_time(value: Optional[str]) -> Optional[datetime]:
-    """Parse a metadata sync_time into an aware UTC datetime, or None."""
-    if not value or value == "unknown":
+def parse_sync_time(value: object) -> Optional[datetime]:
+    """Parse a metadata sync_time into an aware UTC datetime, or None.
+
+    Total by design. Metadata lives in a mutable, network-populated directory
+    that users can mount over, and this runs during server construction -- a
+    malformed value must degrade to "unknown", never raise.
+    """
+    if not isinstance(value, str) or not value or value == "unknown":
         return None
     try:
         parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
@@ -207,28 +212,42 @@ def parse_sync_time(value: Optional[str]) -> Optional[datetime]:
 
 
 def get_docs_snapshot_age(docs_path: Path, version: Optional[str] = None) -> tuple[Optional[str], Optional[int]]:
-    """Return (sync_time, age_in_days) for the freshest documentation snapshot.
+    """Return (sync_date, age_in_days) for the documentation snapshot.
 
-    Checks the requested version, or every supported version when none is given,
-    and reports the most recent sync. Returns (None, None) when no metadata is
-    readable, which is the normal case for a fresh checkout.
+    For a specific version, reports that version. Across all versions, reports
+    the *oldest* one: the caller is asking whether the corpus can be trusted,
+    and the answer is governed by its stalest part. Reporting the newest would
+    describe a version the user may not be reading.
+
+    Returns (None, None) when no metadata is readable, or when a timestamp is
+    in the future -- a clock skew we cannot interpret and must not present as
+    fresh.
     """
     # Callers reach this through server construction, where docs_path may still
     # be a plain string; joining one would raise rather than report "unknown".
     base = Path(docs_path)
-    versions = [version] if version else SUPPORTED_VERSIONS
-    newest: Optional[datetime] = None
+    versions = [version] if version is not None else SUPPORTED_VERSIONS
+    oldest: Optional[datetime] = None
 
     for candidate in versions:
-        synced = parse_sync_time(get_laravel_docs_metadata(base, candidate).get("sync_time"))
-        if synced and (newest is None or synced > newest):
-            newest = synced
+        metadata = get_laravel_docs_metadata(base, candidate)
+        if not isinstance(metadata, dict):
+            continue
+        synced = parse_sync_time(metadata.get("sync_time"))
+        if synced and (oldest is None or synced < oldest):
+            oldest = synced
 
-    if newest is None:
+    if oldest is None:
         return None, None
 
-    age = (datetime.now(timezone.utc) - newest).days
-    return newest.strftime("%Y-%m-%d"), max(age, 0)
+    age = (datetime.now(timezone.utc) - oldest).days
+    if age < 0:
+        # Timestamp is in the future. Treating it as fresh would permanently
+        # disable the staleness warning under routine container clock skew.
+        logger.warning(f"Documentation sync_time is in the future: {oldest.isoformat()}")
+        return None, None
+
+    return oldest.strftime("%Y-%m-%d"), age
 
 
 def describe_docs_freshness(docs_path: Path, version: Optional[str] = None) -> str:
@@ -241,10 +260,15 @@ def describe_docs_freshness(docs_path: Path, version: Optional[str] = None) -> s
     return f"{snapshot} ({age} day{'s' if age != 1 else ''} ago)"
 
 
-def docs_are_stale(docs_path: Path, version: Optional[str] = None) -> bool:
-    """Whether the snapshot is old enough to be worth mentioning."""
-    _, age = get_docs_snapshot_age(docs_path, version)
-    return age is not None and age > DOCS_STALE_AFTER_DAYS
+def docs_are_stale(docs_path: Path, version: Optional[str] = None, age_days: Optional[int] = None) -> bool:
+    """Whether the snapshot is old enough to be worth mentioning.
+
+    Pass `age_days` when the caller has already computed it, to avoid re-reading
+    every version's metadata a second time.
+    """
+    if age_days is None:
+        _, age_days = get_docs_snapshot_age(docs_path, version)
+    return age_days is not None and age_days > DOCS_STALE_AFTER_DAYS
 
 
 def get_laravel_docs_metadata(docs_path: Path, version: str) -> dict:

--- a/tests/unit/test_docs_freshness.py
+++ b/tests/unit/test_docs_freshness.py
@@ -1,0 +1,133 @@
+"""Tests for documentation freshness reporting.
+
+Documentation ships as a snapshot, so it ages. The failure mode this guards
+against is silent: an assistant answering confidently about a recent Laravel
+feature from a corpus months out of date, with nothing in the output hinting
+that the corpus is old.
+"""
+
+import json
+import time
+
+import pytest
+
+from mcp_tools import (
+    DOCS_STALE_AFTER_DAYS,
+    describe_docs_freshness,
+    docs_are_stale,
+    get_docs_snapshot_age,
+    parse_sync_time,
+)
+
+
+def write_snapshot(docs_path, days_old, version="12.x"):
+    """Create documentation metadata synced `days_old` days ago."""
+    metadata_dir = docs_path / version / ".metadata"
+    metadata_dir.mkdir(parents=True, exist_ok=True)
+    synced = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() - days_old * 86400))
+    (metadata_dir / "sync_info.json").write_text(
+        json.dumps({"version": version, "sync_time": synced, "commit_sha": "abc1234"})
+    )
+    return synced
+
+
+class TestSnapshotAge:
+    @pytest.mark.parametrize("days", [0, 1, 5, 45, 400])
+    def test_reports_age_in_days(self, tmp_path, days):
+        write_snapshot(tmp_path, days)
+        _, age = get_docs_snapshot_age(tmp_path)
+        assert age == days
+
+    def test_reports_newest_version_when_several_exist(self, tmp_path):
+        write_snapshot(tmp_path, 90, version="11.x")
+        write_snapshot(tmp_path, 3, version="12.x")
+        _, age = get_docs_snapshot_age(tmp_path)
+        assert age == 3, "should report the freshest snapshot, not the oldest"
+
+    def test_missing_metadata_is_not_an_error(self, tmp_path):
+        assert get_docs_snapshot_age(tmp_path) == (None, None)
+
+    def test_corrupt_timestamp_is_not_an_error(self, tmp_path):
+        metadata_dir = tmp_path / "12.x" / ".metadata"
+        metadata_dir.mkdir(parents=True)
+        (metadata_dir / "sync_info.json").write_text(json.dumps({"sync_time": "garbage"}))
+        assert get_docs_snapshot_age(tmp_path) == (None, None)
+
+
+class TestStaleness:
+    def test_fresh_docs_are_not_stale(self, tmp_path):
+        write_snapshot(tmp_path, 1)
+        assert docs_are_stale(tmp_path) is False
+
+    def test_docs_just_inside_the_threshold_are_not_stale(self, tmp_path):
+        write_snapshot(tmp_path, DOCS_STALE_AFTER_DAYS)
+        assert docs_are_stale(tmp_path) is False
+
+    def test_docs_past_the_threshold_are_stale(self, tmp_path):
+        write_snapshot(tmp_path, DOCS_STALE_AFTER_DAYS + 1)
+        assert docs_are_stale(tmp_path) is True
+
+    def test_unknown_age_is_not_reported_as_stale(self, tmp_path):
+        """Absent metadata must not produce a false staleness warning."""
+        assert docs_are_stale(tmp_path) is False
+
+
+class TestFreshnessDescription:
+    def test_today_reads_naturally(self, tmp_path):
+        write_snapshot(tmp_path, 0)
+        assert "today" in describe_docs_freshness(tmp_path)
+
+    def test_singular_day(self, tmp_path):
+        write_snapshot(tmp_path, 1)
+        assert "1 day ago" in describe_docs_freshness(tmp_path)
+
+    def test_plural_days(self, tmp_path):
+        write_snapshot(tmp_path, 12)
+        assert "12 days ago" in describe_docs_freshness(tmp_path)
+
+    def test_unknown_when_never_synced(self, tmp_path):
+        assert "unknown" in describe_docs_freshness(tmp_path)
+
+
+class TestParseSyncTime:
+    @pytest.mark.parametrize("value", [None, "", "unknown", "not-a-date", "2026-13-45"])
+    def test_unparseable_values_return_none(self, value):
+        assert parse_sync_time(value) is None
+
+    def test_naive_timestamps_are_treated_as_utc(self):
+        parsed = parse_sync_time("2026-07-30T12:00:00")
+        assert parsed is not None and parsed.tzinfo is not None
+
+    def test_zulu_suffix_is_understood(self):
+        parsed = parse_sync_time("2026-07-30T12:00:00Z")
+        assert parsed is not None and parsed.year == 2026
+
+
+class TestServerInstructions:
+    """The assistant learns the snapshot age from the server instructions."""
+
+    def test_instructions_state_the_snapshot_age(self, tmp_path):
+        from laravel_mcp_companion import build_server_instructions
+
+        write_snapshot(tmp_path, 45)
+        instructions = build_server_instructions(tmp_path, "12.x")
+
+        assert "45 days ago" in instructions
+        assert "update_laravel_docs" in instructions, (
+            "instructions must tell the assistant how to refresh"
+        )
+
+    def test_instructions_cover_usage_and_default_version(self, tmp_path):
+        from laravel_mcp_companion import build_server_instructions
+
+        write_snapshot(tmp_path, 1)
+        instructions = build_server_instructions(tmp_path, "11.x")
+
+        assert "search_laravel_docs" in instructions
+        assert "11.x" in instructions
+
+    def test_instructions_survive_missing_metadata(self, tmp_path):
+        from laravel_mcp_companion import build_server_instructions
+
+        instructions = build_server_instructions(tmp_path, "12.x")
+        assert "unknown" in instructions

--- a/tests/unit/test_docs_freshness.py
+++ b/tests/unit/test_docs_freshness.py
@@ -8,6 +8,7 @@ that the corpus is old.
 
 import json
 import time
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -38,20 +39,53 @@ class TestSnapshotAge:
         _, age = get_docs_snapshot_age(tmp_path)
         assert age == days
 
-    def test_reports_newest_version_when_several_exist(self, tmp_path):
+    def test_reports_the_requested_version_not_the_freshest(self, tmp_path):
+        """A pinned old version must not inherit a newer version's freshness."""
+        write_snapshot(tmp_path, 101, version="11.x")
+        write_snapshot(tmp_path, 0, version="13.x")
+
+        _, age = get_docs_snapshot_age(tmp_path, "11.x")
+        assert age == 101, "asking about 11.x must report 11.x"
+
+    def test_aggregate_reports_the_oldest_version(self, tmp_path):
+        """Across versions, trustworthiness is governed by the stalest part."""
         write_snapshot(tmp_path, 90, version="11.x")
         write_snapshot(tmp_path, 3, version="12.x")
+
         _, age = get_docs_snapshot_age(tmp_path)
-        assert age == 3, "should report the freshest snapshot, not the oldest"
+        assert age == 90, "the aggregate must not quote the freshest version"
 
     def test_missing_metadata_is_not_an_error(self, tmp_path):
         assert get_docs_snapshot_age(tmp_path) == (None, None)
 
-    def test_corrupt_timestamp_is_not_an_error(self, tmp_path):
+    @pytest.mark.parametrize("sync_time", [
+        "garbage", "2026-13-45", "", None, 1753900000, 12.5, True,
+        {"nested": "object"}, ["list"],
+    ])
+    def test_malformed_sync_time_is_never_fatal(self, tmp_path, sync_time):
+        """Metadata is user-mountable and network-populated; it must never raise."""
+        metadata_dir = tmp_path / "12.x" / ".metadata"
+        metadata_dir.mkdir(parents=True, exist_ok=True)
+        (metadata_dir / "sync_info.json").write_text(json.dumps({"sync_time": sync_time}))
+        assert get_docs_snapshot_age(tmp_path) == (None, None)
+
+    def test_metadata_that_is_not_an_object_is_not_fatal(self, tmp_path):
         metadata_dir = tmp_path / "12.x" / ".metadata"
         metadata_dir.mkdir(parents=True)
-        (metadata_dir / "sync_info.json").write_text(json.dumps({"sync_time": "garbage"}))
+        (metadata_dir / "sync_info.json").write_text('["not", "an", "object"]')
         assert get_docs_snapshot_age(tmp_path) == (None, None)
+
+    @pytest.mark.parametrize("days_ahead", [1, 2, 365])
+    def test_future_timestamps_report_unknown(self, tmp_path, days_ahead):
+        """Clock skew must not be presented as freshness.
+
+        Clamping a future age to zero would render the snapshot permanently
+        'today' and silently disable the staleness warning.
+        """
+        write_snapshot(tmp_path, -days_ahead)
+        assert get_docs_snapshot_age(tmp_path) == (None, None)
+        assert docs_are_stale(tmp_path) is False
+        assert "unknown" in describe_docs_freshness(tmp_path)
 
 
 class TestStaleness:
@@ -90,17 +124,27 @@ class TestFreshnessDescription:
 
 
 class TestParseSyncTime:
-    @pytest.mark.parametrize("value", [None, "", "unknown", "not-a-date", "2026-13-45"])
+    @pytest.mark.parametrize("value", [
+        None, "", "unknown", "not-a-date", "2026-13-45", 1753900000, 12.5, True, {}, [],
+    ])
     def test_unparseable_values_return_none(self, value):
         assert parse_sync_time(value) is None
 
     def test_naive_timestamps_are_treated_as_utc(self):
         parsed = parse_sync_time("2026-07-30T12:00:00")
-        assert parsed is not None and parsed.tzinfo is not None
+        assert parsed is not None
+        assert parsed.utcoffset() == timedelta(0), "a naive timestamp must be read as UTC"
 
     def test_zulu_suffix_is_understood(self):
         parsed = parse_sync_time("2026-07-30T12:00:00Z")
-        assert parsed is not None and parsed.year == 2026
+        assert parsed == datetime(2026, 7, 30, 12, 0, 0, tzinfo=timezone.utc)
+
+    def test_explicit_offset_is_converted_not_ignored(self):
+        """+02:00 is two hours ahead of the same wall-clock time in UTC."""
+        offset = parse_sync_time("2026-07-30T12:00:00+02:00")
+        utc = parse_sync_time("2026-07-30T12:00:00Z")
+        assert offset is not None and utc is not None
+        assert offset == utc - timedelta(hours=2)
 
 
 class TestServerInstructions:
@@ -117,17 +161,63 @@ class TestServerInstructions:
             "instructions must tell the assistant how to refresh"
         )
 
-    def test_instructions_cover_usage_and_default_version(self, tmp_path):
+    def test_instructions_report_the_served_version_not_the_freshest(self, tmp_path):
+        """The bug this guards: a pinned old version inheriting a newer one's date.
+
+        A user on 11.x whose docs are 101 days old must not be told the corpus
+        was synced today because 13.x happens to be current.
+        """
+        from laravel_mcp_companion import build_server_instructions
+
+        write_snapshot(tmp_path, 101, version="11.x")
+        write_snapshot(tmp_path, 0, version="13.x")
+
+        instructions = build_server_instructions(tmp_path, "11.x")
+
+        assert "101 days ago" in instructions
+        assert "(today)" not in instructions
+
+    def test_instructions_name_the_default_version_explicitly(self, tmp_path):
+        from laravel_mcp_companion import build_server_instructions
+
+        write_snapshot(tmp_path, 1, version="11.x")
+        instructions = build_server_instructions(tmp_path, "11.x")
+
+        # The bare string "11.x" also appears in the supported-versions list, so
+        # assert the phrase that actually depends on runtime_version.
+        assert "default to Laravel 11.x" in instructions
+
+    @pytest.mark.parametrize("mode,expected,forbidden", [
+        ("search", "search_tools", "read_laravel_doc_content"),
+        (None, "read_laravel_doc_content", "search_tools"),
+        ("code", "get_schema", "read_laravel_doc_content"),
+    ])
+    def test_instructions_describe_the_exposed_tool_surface(self, tmp_path, mode, expected, forbidden):
+        """Transforms replace the individual tools, so the described flow must follow.
+
+        Naming hidden tools invites calls the client cannot route.
+        """
         from laravel_mcp_companion import build_server_instructions
 
         write_snapshot(tmp_path, 1)
-        instructions = build_server_instructions(tmp_path, "11.x")
+        instructions = build_server_instructions(tmp_path, "12.x", transform_mode=mode)
 
-        assert "search_laravel_docs" in instructions
-        assert "11.x" in instructions
+        assert expected in instructions
+        assert forbidden not in instructions
 
     def test_instructions_survive_missing_metadata(self, tmp_path):
         from laravel_mcp_companion import build_server_instructions
 
         instructions = build_server_instructions(tmp_path, "12.x")
         assert "unknown" in instructions
+
+    def test_server_starts_with_corrupt_metadata(self, tmp_path):
+        """Instructions are built during server construction, so this must not raise."""
+        from laravel_mcp_companion import create_mcp_server
+
+        metadata_dir = tmp_path / "12.x" / ".metadata"
+        metadata_dir.mkdir(parents=True)
+        (metadata_dir / "sync_info.json").write_text(json.dumps({"sync_time": 1753900000}))
+
+        server = create_mcp_server("Test", tmp_path, "12.x", transform_mode=None)
+        assert server is not None

--- a/tests/unit/test_laravel_mcp_companion_main.py
+++ b/tests/unit/test_laravel_mcp_companion_main.py
@@ -101,7 +101,12 @@ class TestMainFunction:
             
             # Verify setup was called
             mock_setup_docs.assert_called_once()
-            mock_fastmcp_class.assert_called_once_with("LaravelMCPCompanion")
+            # The server is constructed with its name plus instructions telling
+            # the assistant how old the documentation snapshot is.
+            mock_fastmcp_class.assert_called_once()
+            args, kwargs = mock_fastmcp_class.call_args
+            assert args[0] == "LaravelMCPCompanion"
+            assert "instructions" in kwargs and kwargs["instructions"]
             mock_updater_class.assert_called_once_with(temp_dir, DEFAULT_VERSION)
             
             # Verify server was started (stdio is default, no args needed)


### PR DESCRIPTION
Addresses the UX concern that our tagging work made "just give me current Laravel docs" harder rather than easier.

## The problem was the layer, not the tags

The README section I first drafted needed ~60 lines of caveats to explain how to stay current — which is the tell. Every option pushed maintenance onto the user:

- `:latest` doesn't help by itself, because `docker run` reuses the image you already pulled
- `--pull=always` costs a network round trip on every start and gives up **"Offline documentation access"**, which the README advertises as a differentiator
- `--update-docs` only refreshes core Laravel docs, and with `--rm` re-downloads every launch
- `docs-*` vs `vX.Y.Z` tag naming is versioning hygiene that users shouldn't have to learn

And none of it addresses the real failure, which is **silent**: someone installs this once, forgets it exists, and six months later asks about a Laravel 13 feature. They get a confident answer from a stale snapshot with no indication anything is out of date. No tag scheme fixes that, because it depends on remembering maintenance you never think about.

## Surface the age instead

The server already has `update_laravel_docs`. What was missing is that nothing told the **assistant** how old the corpus was — so it couldn't reason about it.

**Server instructions** (which this server never set at all, flagged as a gap in the earlier audit) now describe what the server covers, the search-then-read flow, the default Laravel version, and the snapshot date:

> The documentation is a local snapshot, last synced 2026-06-16 (45 days ago). If you are asked about a feature that may have landed after that date, say so rather than answering from the snapshot, and offer to run update_laravel_docs […]

**`laravel_docs_info`** now reports `snapshot_date` and `snapshot_age_days`, plus an explicit note past 30 days — so "how current are your Laravel docs?" just works:

```
snapshot_date: 2026-06-16
snapshot_age_days: 45
note: This snapshot is more than 30 days old. Run update_laravel_docs() before
      relying on it for recent features.
```

Zero configuration, offline stays intact, and nobody has to learn tag naming.

## README, rewritten around the question people ask

Cut to what a user wants to know: `:latest` carries the newest docs, `docker run` reuses what you already pulled, `--pull=always` automates it if you want. Plus a note that the assistant tracks freshness for you. The `docs-*` scheme is gone from the user-facing path.

## Fails safe

Freshness reporting never invents a problem. Missing metadata, corrupt timestamps, and unparseable dates all report `unknown` rather than raising or claiming false staleness — verified for each. A `docs_path` passed as a string is coerced rather than blowing up during server construction; that one was a genuine bug my first version introduced, caught by an existing test that passes `"/tmp/test"`.

## Test plan

- [x] 546 tests pass (was 520); ruff, mypy across 36 files, coverage 66.34%, Inspector smoke test
- [x] 26 new tests covering age reporting, the staleness boundary at exactly 30/31 days, singular vs plural phrasing, corrupt and missing metadata, and instruction content
- [x] Verified over a real MCP client session that instructions reach `initialize` and carry the age and refresh guidance
- [x] Verified `laravel_docs_info` flags a 45-day-old snapshot and stays quiet on a fresh one

## Note

`:latest` is genuinely stale right now — the `v0.10.1` tag published no image because of the release trigger issue in #381. The README's claim that `:latest` has the newest docs becomes true once that trigger matches both `v*` and `docs-*` again.