### PR TITLE
Validate version in laravel_docs_info, and harden the allowlist's trust root

### DIFF
--- a/docs_updater.py
+++ b/docs_updater.py
@@ -201,6 +201,16 @@ def _read_versions_cache(cache_file: Path, max_age_seconds: float | None = None)
         if not (isinstance(versions, list) and len(versions) > 0):
             return None
 
+        # This list is the trust root for every version allowlist, and it is read
+        # from a file that ships in the image, is tracked in git, and sits in a
+        # directory users bind-mount and the server itself writes to. The API
+        # response is filtered to this shape already; the cache never was, so a
+        # single edited JSON value could smuggle "../.." past every check.
+        versions = [v for v in versions if isinstance(v, str) and re.fullmatch(r"\d+\.x", v)]
+        if not versions:
+            logger.warning("Versions cache contained no well-formed version strings")
+            return None
+
         if max_age_seconds is not None:
             updated_at = data.get("updated_at")
             if not updated_at:
@@ -1480,9 +1490,13 @@ class DocsUpdater:
         # Create version-specific directory. update() clears everything under
         # version_dir, so it must be a strict subdirectory of target_dir --
         # equality would wipe every version in the documentation root.
+        #
+        # Compare the parent rather than resolving version_dir itself: the name
+        # checks above already guarantee a single path component, and resolving
+        # through a symlink rejected legitimately-relocated version directories,
+        # which aborted server startup rather than just the update path.
         self.version_dir = target_dir / version
-        if (not is_within_directory(target_dir, self.version_dir)
-                or self.version_dir.resolve() == target_dir.resolve()):
+        if self.version_dir.parent.resolve() != target_dir.resolve():
             raise ValueError(f"Version directory escapes target directory: {version!r}")
         self.version_dir.mkdir(parents=True, exist_ok=True)
         

--- a/laravel_mcp_companion.py
+++ b/laravel_mcp_companion.py
@@ -1465,6 +1465,12 @@ def configure_mcp_server(mcp: FastMCP, docs_path: Path, runtime_version: str, mu
         """
         logger.debug(f"laravel_docs_info function called (version: {version})")
 
+        # This tool is implemented inline rather than delegating to an *_impl in
+        # mcp_tools, which is how it escaped the validation added everywhere else.
+        version_error = validate_version_arg(version)
+        if version_error:
+            return version_error
+
         if version:
             metadata = get_laravel_docs_metadata(docs_path, version)
 

--- a/tests/unit/test_path_traversal_security.py
+++ b/tests/unit/test_path_traversal_security.py
@@ -289,3 +289,139 @@ class TestAllowlistArgumentParsing:
         args = self._parse(monkeypatch, [], {})
         assert args.cors_origin == []
         assert args.allowed_host == []
+
+
+class TestDocsInfoTraversal:
+    """`laravel_docs_info` is implemented inline rather than via an *_impl.
+
+    That is how it escaped the validation added to every other version-taking
+    tool: it read `<docs>/<version>/.metadata/sync_info.json` with `version`
+    unchecked, giving an arbitrary-directory read and existence oracle that was
+    reachable through the default search transform's call_tool proxy.
+    """
+
+    @pytest.mark.parametrize("bad_version", [
+        "../secretzone", "../secretzone/", "./../secretzone",
+        "12.x/../../secretzone", "12.x/./../../secretzone", "..", "/etc",
+    ])
+    @pytest.mark.asyncio
+    async def test_rejects_traversal_version(self, tmp_path, bad_version):
+        import json
+        from fastmcp import Client
+        from laravel_mcp_companion import create_mcp_server
+
+        docs = tmp_path / "docs"
+        (docs / "12.x" / ".metadata").mkdir(parents=True)
+        (docs / "12.x" / "blade.md").write_text("# Blade")
+        (docs / "12.x" / ".metadata" / "sync_info.json").write_text(
+            json.dumps({"version": "12.x", "sync_time": "2026-07-30T00:00:00Z"})
+        )
+
+        # A metadata file planted outside the documentation tree
+        outside = tmp_path / "secretzone" / ".metadata"
+        outside.mkdir(parents=True)
+        (outside / "sync_info.json").write_text(json.dumps({
+            "version": "x", "sync_time": "2026-07-01T00:00:00Z",
+            "commit_sha": "PROXY-CANARY", "commit_message": "PROXY-CANARY",
+        }))
+
+        server = create_mcp_server("T", docs, "12.x", transform_mode=None)
+        async with Client(server) as client:
+            result = await client.call_tool("laravel_docs_info", {"version": bad_version})
+            text = result.content[0].text if result.content else ""
+
+        assert "PROXY-CANARY" not in text, f"leaked via version={bad_version!r}"
+        assert "Invalid version" in text
+
+    @pytest.mark.asyncio
+    async def test_legitimate_version_still_works(self, tmp_path):
+        import json
+        from fastmcp import Client
+        from laravel_mcp_companion import create_mcp_server
+        from mcp_tools import SUPPORTED_VERSIONS
+
+        version = SUPPORTED_VERSIONS[-1]
+        docs = tmp_path / "docs"
+        (docs / version / ".metadata").mkdir(parents=True)
+        (docs / version / ".metadata" / "sync_info.json").write_text(
+            json.dumps({"version": version, "sync_time": "2026-07-30T00:00:00Z",
+                        "commit_sha": "abc1234"})
+        )
+
+        server = create_mcp_server("T", docs, version, transform_mode=None)
+        async with Client(server) as client:
+            result = await client.call_tool("laravel_docs_info", {"version": version})
+            text = result.content[0].text if result.content else ""
+
+        assert "abc1234" in text
+
+
+class TestVersionsCacheIsTrustworthy:
+    """SUPPORTED_VERSIONS is the trust root for every version allowlist.
+
+    It is read from a JSON file that ships in the image, is tracked in git, and
+    lives in a directory users bind-mount. The GitHub API response was filtered
+    to `\\d+\\.x`; the cache read was not, so one edited value disabled every check.
+    """
+
+    @pytest.mark.parametrize("poisoned", [
+        "../secretzone", "..", ".", "/etc", "12.x/../..", "", 42, None, {"a": 1},
+    ])
+    def test_malformed_cache_entries_are_discarded(self, tmp_path, poisoned):
+        import json
+        from docs_updater import get_supported_versions
+
+        cache = tmp_path / "versions.json"
+        cache.write_text(json.dumps({
+            "versions": ["12.x", poisoned],
+            "updated_at": "2099-01-01T00:00:00+00:00",
+        }))
+
+        versions = get_supported_versions(cache_file=cache)
+        assert poisoned not in versions
+        assert versions == ["12.x"]
+
+    def test_cache_of_only_bad_entries_falls_through(self, tmp_path):
+        """A wholly malformed cache must not become the allowlist."""
+        import json
+        from docs_updater import get_supported_versions
+
+        cache = tmp_path / "versions.json"
+        cache.write_text(json.dumps({
+            "versions": ["../etc", "."],
+            "updated_at": "2099-01-01T00:00:00+00:00",
+        }))
+
+        versions = get_supported_versions(cache_file=cache)
+        assert "../etc" not in versions and "." not in versions
+
+
+class TestSymlinkedVersionDirectory:
+    """Relocating a version directory via symlink is legitimate, not an attack."""
+
+    def test_symlinked_version_dir_is_accepted(self, tmp_path):
+        import os
+        from docs_updater import DocsUpdater
+
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        os.symlink(elsewhere, docs / "12.x")
+
+        updater = DocsUpdater(docs, "12.x")
+        assert updater.version_dir == docs / "12.x"
+
+    def test_server_starts_with_symlinked_version_dir(self, tmp_path):
+        """This previously aborted startup, not merely the update path."""
+        import os
+        from laravel_mcp_companion import create_mcp_server
+
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        (elsewhere / "blade.md").write_text("# Blade")
+        os.symlink(elsewhere, docs / "12.x")
+
+        assert create_mcp_server("T", docs, "12.x", transform_mode=None) is not None


### PR DESCRIPTION
An adversarial review of the v0.10.0 security work found its headline claim false. That commit stated the `version` argument was validated *"in every tool implementation"* — the validator is called exactly once:

```
$ git show v0.10.0:laravel_mcp_companion.py | grep -n "validate_version_arg"
52:    validate_version as validate_version_arg,
1459:        version_error = validate_version_arg(version_param)   # update_laravel_docs only
```

## 1. `laravel_docs_info` traversal — live on main

It is the one version-taking tool implemented inline instead of delegating to an `*_impl` in `mcp_tools.py`, which is exactly how it escaped the sweep. `version` reached `get_laravel_docs_metadata(docs_path, version)` → `docs_path / version / ".metadata" / "sync_info.json"` → `open()`.

Reproduced through a real MCP client in the **default** `--transform-mode search` configuration, via the `call_tool` proxy:

```
call_tool {"name": "laravel_docs_info", "arguments": {"version": "../secretzone"}}
→ commit_sha: PROXY-CANARY-4417
  commit_message: PROXY-CANARY-4417
LEAKED via default search transport: True
```

Working payloads included `../secretzone`, `./../secretzone`, `12.x/../../secretzone`, and absolute paths (`Path.__truediv__` discards the base when the operand is absolute).

**Primitive:** read any `<dir>/.metadata/sync_info.json` on the filesystem whose JSON carries a `version` key, echoing back `sync_time`, `commit_sha`, `commit_date`, `commit_message` and `commit_url` — plus an existence oracle for that path anywhere on disk. Narrow filenames, but arbitrary directory and unauthenticated.

That the *same arguments* were correctly rejected by `list_laravel_docs` is what makes this an oversight rather than a design choice. None of the 47 regression tests added in v0.10.0 covered this tool.

## 2. The allowlist's trust root was unvalidated

`validate_version` is only as strong as `SUPPORTED_VERSIONS`, which comes from `docs/.versions_cache.json`. The `\d+\.x` shape was enforced **only** on the GitHub API response — never on the cache read. With a poisoned cache:

```
SUPPORTED_VERSIONS = ['12.x', '../secretzone']
read_laravel_doc_content(filename='passwd.md', version='../secretzone')
  → POISON-CANARY root:x:0:0
```

Every downstream check opens up at once, because `is_safe_path` derives its base from `docs_path / version` — a traversing "version" moves the base with it.

Not remotely triggerable today, but that file is tracked in git, ships inside the Docker image, and lives in a directory the server writes to and users routinely bind-mount. A single edited JSON value disabled the entire fix with nothing at runtime to catch it. Now filtered on read.

## 3. Regression from the same security pass: symlinks broke startup

`DocsUpdater.__init__` resolved `version_dir` *through* a symlink, so a legitimately relocated version directory was rejected:

```
❌ REJECTED legitimate symlinked version dir: Version directory escapes target directory: '12.x'
```

Because `MultiSourceDocsUpdater` is constructed inside `create_mcp_server`, this aborted **server startup**, not merely the update path — far wider blast radius than the check was meant to have. It now compares the parent directory; `is_safe_section_name(version)` plus the no-separator check already guarantee a single path component, so resolving bought nothing except the breakage.

## Test plan

- [x] 540 tests pass (was 514 on main); ruff and mypy clean; coverage 66.01%
- [x] New regression tests for each finding, with the traversal driven **through a real MCP client** rather than by calling the impl directly — that's the layer where it was actually exploitable
- [x] Verified the canary leaks before the fix and is rejected after
- [x] Verified legitimate `laravel_docs_info` calls, symlinked version directories, and server startup all still work

## Still outstanding from the same review

Not fixed here, deliberately, since they need judgement rather than a patch:

- **TOCTOU** between `is_safe_path` and `open()` — the check resolves the path, discards it, and the caller opens the unresolved one. Won the race in 7 attempts locally, though it requires the ability to create symlinks inside the docs tree. Fix is to open the resolved path, or `O_NOFOLLOW`.
- **Enumeration paths skip containment**: `list_laravel_docs` and both search impls enumerate with `os.listdir`/`glob` and read without `is_safe_path`, so a symlinked file inside a version directory is listed and match-counted while direct reads of it are denied.
- **`ALLOWED_HOSTS=*` silently disables the Host guard** — FastMCP runs allowed hosts through `fnmatchcase`. Worth rejecting wildcards the way `--cors-origin` already does.