### PR TITLE
Make every path agree on containment, and reject wildcard hosts

### DIFF
--- a/laravel_mcp_companion.py
+++ b/laravel_mcp_companion.py
@@ -771,6 +771,17 @@ def parse_arguments():
     if args.allowed_host is None:
         args.allowed_host = _split_env_list("ALLOWED_HOSTS") or []
 
+    # Allowed hosts are matched with fnmatch, so a pattern entry would match
+    # every Host header and silently disable the guard while still looking like
+    # a configured allowlist. Reject them the way wildcard CORS origins are.
+    wildcard_hosts = [h for h in args.allowed_host if any(c in h for c in "*?[")]
+    if wildcard_hosts:
+        parser.error(
+            f"wildcard patterns are not accepted in allowed hosts: {', '.join(wildcard_hosts)}. "
+            "List each hostname explicitly; a pattern would match every Host header "
+            "and disable DNS-rebinding protection."
+        )
+
     return args
 
 def setup_docs_path(user_path: Optional[str] = None) -> Path:

--- a/laravel_mcp_companion.py
+++ b/laravel_mcp_companion.py
@@ -48,7 +48,7 @@ from mcp_tools import (
     search_laravel_learning_resources_impl,
     list_laravel_learning_resources_impl,
     list_laravel_categories_impl,
-    is_safe_path,
+    resolve_contained_path,
     validate_version as validate_version_arg,
     count_matches,
     clear_caches as clear_mcp_tools_caches,
@@ -1359,23 +1359,25 @@ def create_mcp_server(server_name: str, docs_path: Path, runtime_version: str, t
         
         file_path = Path(config['docs_path']) / version_inner / relative_path
         
-        # Security check - ensure we stay within version directory
+        # Security check - read the resolved path this returns, not file_path,
+        # so the file that was checked is the file that gets opened.
         version_path = Path(config['docs_path']) / version_inner
-        if not is_safe_path(version_path, file_path):
+        safe_path = resolve_contained_path(version_path, file_path)
+        if safe_path is None:
             logger.warning(f"Access denied: {path} (attempted directory traversal)")
             return f"Access denied: {path} (attempted directory traversal)"
-        
-        if not file_path.exists():
-            logger.warning(f"Documentation file not found: {file_path}")
+
+        if not safe_path.exists():
+            logger.warning(f"Documentation file not found: {safe_path}")
             return f"Documentation file not found: {path} (version: {version_inner})"
-        
+
         try:
-            content = get_file_content_cached(str(file_path))
+            content = get_file_content_cached(str(safe_path))
             if not content.startswith("Error") and not content.startswith("File not found"):
-                logger.debug(f"Successfully read file: {file_path} ({len(content)} bytes)")
+                logger.debug(f"Successfully read file: {safe_path} ({len(content)} bytes)")
             return content
         except Exception as e:
-            logger.error(f"Error reading file {file_path}: {str(e)}")
+            logger.error(f"Error reading file {safe_path}: {str(e)}")
             return f"Error reading file: {str(e)}"
     
     def read_external_laravel_doc(service: str, path: str) -> str:
@@ -1397,11 +1399,13 @@ def create_mcp_server(server_name: str, docs_path: Path, runtime_version: str, t
             
             file_path = service_dir / path
             
-            # Security check - ensure we stay within service directory
-            if not is_safe_path(service_dir, file_path):
+            # Security check - open the resolved path this returns, not
+            # file_path, so the check and the open see the same file.
+            safe_path = resolve_contained_path(service_dir, file_path)
+            if safe_path is None:
                 return f"Access denied: {service}/{path} (path traversal attempted)"
-            
-            if not file_path.exists():
+
+            if not safe_path.exists():
                 # List available files to help user
                 available_files = []
                 try:
@@ -1414,9 +1418,9 @@ def create_mcp_server(server_name: str, docs_path: Path, runtime_version: str, t
                 else:
                     return f"File not found: {service}/{path}. No documentation cached for {service}. Use update_external_laravel_docs(['{service}']) to fetch documentation."
             
-            with open(file_path, 'r', encoding='utf-8') as f:
+            with open(safe_path, 'r', encoding='utf-8') as f:
                 content = f.read()
-                logger.debug(f"Successfully read external file: {file_path} ({len(content)} bytes)")
+                logger.debug(f"Successfully read external file: {safe_path} ({len(content)} bytes)")
                 return content
         except Exception as e:
             logger.error(f"Error reading external file {service}/{path}: {str(e)}")

--- a/mcp_tools.py
+++ b/mcp_tools.py
@@ -66,15 +66,38 @@ _search_result_cache: Dict[str, str] = {}
 _cache_lock = threading.Lock()
 
 
+def _no_follow_opener(path, flags):
+    """open() opener that refuses to follow a symlink in the final component.
+
+    Passed to open() rather than calling os.open directly so that the read still
+    goes through the normal open(), which keeps the behaviour observable to
+    callers and testable in the usual way.
+
+    O_NOFOLLOW is POSIX. Where it is unavailable this degrades to an ordinary
+    open rather than refusing to read anything.
+    """
+    return os.open(path, flags | getattr(os, "O_NOFOLLOW", 0))
+
+
 def get_file_content_cached(file_path: str) -> str:
-    """Get file content with caching."""
+    """Get file content with caching.
+
+    Refuses to open a path whose final component is a symbolic link. Containment
+    is checked before the open, and a path that is a regular file when checked
+    can be replaced by a link before it is opened -- resolving first does not
+    help, because a regular file resolves to itself. O_NOFOLLOW closes that
+    window by making the refusal part of the open itself.
+
+    Callers that legitimately want a linked file should resolve it first (see
+    resolve_contained_path) and pass the resolved path, which is not a link.
+    """
     with _cache_lock:
         if file_path in _file_content_cache:
             logger.debug(f"Cache hit for file: {file_path}")
             return _file_content_cache[file_path]
 
     try:
-        with open(file_path, 'r', encoding='utf-8') as f:
+        with open(file_path, 'r', encoding='utf-8', opener=_no_follow_opener) as f:
             content = f.read()
 
         # Cache the content
@@ -115,40 +138,72 @@ def get_version_from_path(path: str, runtime_version: Optional[str] = None) -> t
         return default_version, path
 
 
-def is_safe_path(base_path: Path, target_path: Path) -> bool:
-    """Check if target path is within base path (prevent directory traversal).
+def resolve_contained_path(base_path: Path, target_path: Path) -> Optional[Path]:
+    """Resolve target_path, returning it only if it lands inside base_path.
 
-    Uses is_relative_to() on fully resolved paths. A plain string prefix check is
-    not sufficient: it treats "/docs/12.x-backup" as living under "/docs/12.x".
+    Callers must read the path this returns, not the one they passed in.
+    Validating one path and then opening another leaves a window in which a
+    symlink can be swapped between the check and the open, so the file that was
+    approved and the file that gets read need not be the same one.
 
-    Fails closed: any error resolving either path denies access.
+    Uses is_relative_to() on fully resolved paths. A plain string prefix check
+    is not sufficient: it treats "/docs/12.x-backup" as living under "/docs/12.x".
+
+    Returns None if the path escapes, or if either path cannot be resolved --
+    any error denies access.
     """
     try:
-        return Path(target_path).resolve().is_relative_to(Path(base_path).resolve())
+        base = Path(base_path).resolve()
+        resolved = Path(target_path).resolve()
     except Exception:
-        return False
+        return None
+    return resolved if resolved.is_relative_to(base) else None
 
 
-def list_contained_markdown(version_path: Path) -> List[str]:
-    """List .md filenames in version_path that actually resolve inside it.
+def is_safe_path(base_path: Path, target_path: Path) -> bool:
+    """Whether target_path resolves to a location inside base_path.
+
+    Prefer resolve_contained_path when the caller goes on to read the file, so
+    that the path checked is the path opened.
+    """
+    return resolve_contained_path(base_path, target_path) is not None
+
+
+def list_contained_markdown(version_path: Path) -> List[tuple[str, Path]]:
+    """Return (name, readable_path) for .md files that stay inside version_path.
 
     Enumeration has to apply the same containment rule as reading. Without it a
     symlink pointing out of the tree is listed and searched while
     read_laravel_doc_content refuses to serve it -- which turns search into an
     oracle over content the read path deliberately withholds.
+
+    The second element is the path callers should read: for a symlink it is the
+    resolved target, since the reader refuses to follow links at open time.
+
+    Only symlinks are resolved. A plain file that is a direct child of
+    version_path cannot escape it, and resolving every file turned a search over
+    the corpus into hundreds of unnecessary readlink walks.
     """
     # Errors are deliberately not swallowed. An unreadable documentation
     # directory must surface as an error, not as "no files found" -- the callers
     # already wrap this and turn exceptions into a message.
+    contained: List[tuple[str, Path]] = []
     with os.scandir(version_path) as entries:
-        names = [e.name for e in entries if e.name.endswith('.md')]
+        for entry in entries:
+            if not entry.name.endswith('.md'):
+                continue
 
-    contained = []
-    for name in names:
-        if is_safe_path(version_path, version_path / name):
-            contained.append(name)
-        else:
-            logger.warning(f"Skipping documentation file outside its version directory: {name}")
+            if not entry.is_symlink():
+                contained.append((entry.name, Path(entry.path)))
+                continue
+
+            resolved = resolve_contained_path(version_path, Path(entry.path))
+            if resolved is not None:
+                contained.append((entry.name, resolved))
+            else:
+                logger.warning(
+                    f"Skipping documentation file outside its version directory: {entry.name}"
+                )
     return contained
 
 
@@ -349,7 +404,7 @@ def list_laravel_docs_impl(docs_path: Path, version: Optional[str] = None, runti
                 )
 
             metadata = get_laravel_docs_metadata(docs_path, version)
-            md_files = sorted(list_contained_markdown(version_path))
+            md_files = sorted(name for name, _ in list_contained_markdown(version_path))
 
             if not md_files:
                 return format_error(f"No documentation files found in version {version}")
@@ -368,7 +423,7 @@ def list_laravel_docs_impl(docs_path: Path, version: Optional[str] = None, runti
                 version_path = docs_path / v
                 if not version_path.is_dir():
                     continue
-                md_files = list_contained_markdown(version_path)
+                md_files = [name for name, _ in list_contained_markdown(version_path)]
                 if md_files:
                     metadata = get_laravel_docs_metadata(docs_path, v)
                     versions_data.append({
@@ -421,23 +476,26 @@ def read_laravel_doc_content_impl(docs_path: Path, filename: str, version: Optio
     
     file_path = docs_path / version / relative_path
     
-    # Security check - ensure we stay within version directory
+    # Security check - ensure we stay within version directory. Read the
+    # resolved path this returns, not file_path: opening the unresolved path
+    # would follow the symlink a second time, after the check.
     version_path = docs_path / version
-    if not is_safe_path(version_path, file_path):
+    safe_path = resolve_contained_path(version_path, file_path)
+    if safe_path is None:
         logger.warning(f"Access denied: {filename} (attempted directory traversal)")
         return f"Access denied: {filename} (attempted directory traversal)"
-    
-    if not file_path.exists():
-        logger.warning(f"Documentation file not found: {file_path}")
+
+    if not safe_path.exists():
+        logger.warning(f"Documentation file not found: {safe_path}")
         return f"Documentation file not found: {filename} (version: {version})"
-    
+
     try:
-        content = get_file_content_cached(str(file_path))
+        content = get_file_content_cached(str(safe_path))
         if not content.startswith("Error") and not content.startswith("File not found"):
-            logger.debug(f"Successfully read file: {file_path} ({len(content)} bytes)")
+            logger.debug(f"Successfully read file: {safe_path} ({len(content)} bytes)")
         return content
     except Exception as e:
-        logger.error(f"Error reading file {file_path}: {str(e)}")
+        logger.error(f"Error reading file {safe_path}: {str(e)}")
         return f"Error reading file: {str(e)}"
 
 
@@ -484,9 +542,7 @@ def search_laravel_docs_impl(docs_path: Path, query: str, version: Optional[str]
             if not version_path.exists():
                 continue
 
-            for file in list_contained_markdown(version_path):
-                file_path = version_path / file
-
+            for file, file_path in list_contained_markdown(version_path):
                 content = get_file_content_cached(str(file_path))
                 if not content.startswith("Error") and not content.startswith("File not found"):
                     count = count_matches(pattern, content)
@@ -580,9 +636,7 @@ def search_laravel_docs_with_context_impl(docs_path: Path, query: str, version: 
             if not version_path.exists():
                 continue
             
-            for file in list_contained_markdown(version_path):
-                file_path = version_path / file
-
+            for file, file_path in list_contained_markdown(version_path):
                 content = get_file_content_cached(str(file_path))
                 if not content.startswith("Error") and not content.startswith("File not found"):
                     matches = list(pattern.finditer(content))

--- a/mcp_tools.py
+++ b/mcp_tools.py
@@ -129,6 +129,29 @@ def is_safe_path(base_path: Path, target_path: Path) -> bool:
         return False
 
 
+def list_contained_markdown(version_path: Path) -> List[str]:
+    """List .md filenames in version_path that actually resolve inside it.
+
+    Enumeration has to apply the same containment rule as reading. Without it a
+    symlink pointing out of the tree is listed and searched while
+    read_laravel_doc_content refuses to serve it -- which turns search into an
+    oracle over content the read path deliberately withholds.
+    """
+    # Errors are deliberately not swallowed. An unreadable documentation
+    # directory must surface as an error, not as "no files found" -- the callers
+    # already wrap this and turn exceptions into a message.
+    with os.scandir(version_path) as entries:
+        names = [e.name for e in entries if e.name.endswith('.md')]
+
+    contained = []
+    for name in names:
+        if is_safe_path(version_path, version_path / name):
+            contained.append(name)
+        else:
+            logger.warning(f"Skipping documentation file outside its version directory: {name}")
+    return contained
+
+
 def validate_version(version: Optional[str]) -> Optional[str]:
     """Validate a caller-supplied Laravel version against the supported allowlist.
 
@@ -183,8 +206,17 @@ def validate_subdirectory(base_dir: Path, name: str) -> bool:
     """
     if not name or '/' in name or '\\' in name or name in ('.', '..') or '\x00' in name:
         return False
+
     candidate = base_dir / name
-    return is_safe_path(base_dir, candidate) and candidate.is_dir()
+    # Compare the parent rather than resolving the candidate. The name checks
+    # above already guarantee a single path component, so this cannot traverse;
+    # resolving instead rejected directories the operator had deliberately
+    # relocated via symlink, which listing and search both accepted -- the same
+    # inconsistency that DocsUpdater had for version directories.
+    try:
+        return candidate.parent.resolve() == base_dir.resolve() and candidate.is_dir()
+    except (OSError, ValueError):
+        return False
 
 
 # Documentation is shipped as a snapshot, so it ages. Past this many days we
@@ -317,7 +349,7 @@ def list_laravel_docs_impl(docs_path: Path, version: Optional[str] = None, runti
                 )
 
             metadata = get_laravel_docs_metadata(docs_path, version)
-            md_files = sorted([f for f in os.listdir(version_path) if f.endswith('.md')])
+            md_files = sorted(list_contained_markdown(version_path))
 
             if not md_files:
                 return format_error(f"No documentation files found in version {version}")
@@ -336,9 +368,7 @@ def list_laravel_docs_impl(docs_path: Path, version: Optional[str] = None, runti
                 version_path = docs_path / v
                 if not version_path.is_dir():
                     continue
-                # Single scandir pass instead of two listdir calls plus a stat per file
-                with os.scandir(version_path) as entries:
-                    md_files = [e.name for e in entries if e.name.endswith('.md') and e.is_file()]
+                md_files = list_contained_markdown(version_path)
                 if md_files:
                     metadata = get_laravel_docs_metadata(docs_path, v)
                     versions_data.append({
@@ -454,18 +484,17 @@ def search_laravel_docs_impl(docs_path: Path, query: str, version: Optional[str]
             if not version_path.exists():
                 continue
 
-            for file in os.listdir(version_path):
-                if file.endswith('.md'):
-                    file_path = version_path / file
+            for file in list_contained_markdown(version_path):
+                file_path = version_path / file
 
-                    content = get_file_content_cached(str(file_path))
-                    if not content.startswith("Error") and not content.startswith("File not found"):
-                        count = count_matches(pattern, content)
-                        if count:
-                            core_results_data.append({
-                                "file": f"{v}/{file}",
-                                "matches": count
-                            })
+                content = get_file_content_cached(str(file_path))
+                if not content.startswith("Error") and not content.startswith("File not found"):
+                    count = count_matches(pattern, content)
+                    if count:
+                        core_results_data.append({
+                            "file": f"{v}/{file}",
+                            "matches": count
+                        })
 
         # Search external documentation if requested
         if include_external and external_dir and external_dir.exists():
@@ -551,33 +580,32 @@ def search_laravel_docs_with_context_impl(docs_path: Path, query: str, version: 
             if not version_path.exists():
                 continue
             
-            for file in os.listdir(version_path):
-                if file.endswith('.md'):
-                    file_path = version_path / file
-                    
-                    content = get_file_content_cached(str(file_path))
-                    if not content.startswith("Error") and not content.startswith("File not found"):
-                        matches = list(pattern.finditer(content))
-                        if matches:
-                            file_results = [f"\n### {v}/{file} ({len(matches)} matches):\n"]
-                            
-                            for i, match in enumerate(matches[:5]):  # Limit to 5 matches per file
-                                start = max(0, match.start() - context_length)
-                                end = min(len(content), match.end() + context_length)
-                                
-                                # Find line boundaries
-                                while start > 0 and content[start] != '\n':
-                                    start -= 1
-                                while end < len(content) and content[end] != '\n':
-                                    end += 1
-                                
-                                context = content[start:end].strip()
-                                # Highlight the match
-                                context = pattern.sub(lambda m: f"**{m.group()}**", context)
-                                
-                                file_results.append(f"Match {i+1}:\n```\n{context}\n```\n")
-                            
-                            results.extend(file_results)
+            for file in list_contained_markdown(version_path):
+                file_path = version_path / file
+
+                content = get_file_content_cached(str(file_path))
+                if not content.startswith("Error") and not content.startswith("File not found"):
+                    matches = list(pattern.finditer(content))
+                    if matches:
+                        file_results = [f"\n### {v}/{file} ({len(matches)} matches):\n"]
+
+                        for i, match in enumerate(matches[:5]):  # Limit to 5 matches per file
+                            start = max(0, match.start() - context_length)
+                            end = min(len(content), match.end() + context_length)
+
+                            # Find line boundaries
+                            while start > 0 and content[start] != '\n':
+                                start -= 1
+                            while end < len(content) and content[end] != '\n':
+                                end += 1
+
+                            context = content[start:end].strip()
+                            # Highlight the match
+                            context = pattern.sub(lambda m: f"**{m.group()}**", context)
+
+                            file_results.append(f"Match {i+1}:\n```\n{context}\n```\n")
+
+                        results.extend(file_results)
         
         # Search external documentation if requested
         if include_external and external_dir and external_dir.exists():

--- a/tests/unit/test_containment_consistency.py
+++ b/tests/unit/test_containment_consistency.py
@@ -189,3 +189,98 @@ class TestLearningResourceSymlinkConsistency:
             learning_with_symlinked_source, source="tutorials"
         )
         assert "intro.md" in result
+
+
+class TestOpensThePathItValidated:
+    """The containment check must hand back the path the caller then opens.
+
+    `is_safe_path` resolved the target, threw the resolved value away, and the
+    caller opened the original. Between those two steps a symlink can be
+    swapped, so the path that was checked and the path that was opened are not
+    guaranteed to be the same file. Resolving once and opening that result
+    closes the window.
+    """
+
+    def test_read_opens_the_resolved_target_not_the_link(self, tmp_path):
+        from unittest.mock import patch
+
+        from mcp_tools import read_laravel_doc_content_impl
+
+        docs = tmp_path / "docs"
+        version_dir = docs / VERSION
+        version_dir.mkdir(parents=True)
+        (version_dir / "real.md").write_text("# Real\n\ncontent")
+        os.symlink(version_dir / "real.md", version_dir / "alias.md")
+
+        with patch("mcp_tools.get_file_content_cached", return_value="# Real") as reader:
+            read_laravel_doc_content_impl(docs, "alias.md", VERSION)
+
+        opened = os.path.basename(reader.call_args[0][0])
+        assert opened == "real.md", (
+            f"opened {opened!r}; must open the resolved path that was validated, "
+            "not the link that was validated through"
+        )
+
+    def test_resolved_contained_path_returns_the_resolution(self, tmp_path):
+        from mcp_tools import resolve_contained_path
+
+        base = tmp_path / "base"
+        base.mkdir()
+        (base / "real.md").write_text("x")
+        os.symlink(base / "real.md", base / "alias.md")
+
+        resolved = resolve_contained_path(base, base / "alias.md")
+
+        assert resolved is not None
+        assert resolved.name == "real.md", "must return what the path resolves to"
+
+    def test_resolved_contained_path_rejects_escapes(self, tmp_path):
+        from mcp_tools import resolve_contained_path
+
+        base = tmp_path / "base"
+        base.mkdir()
+        outside = tmp_path / "outside.md"
+        outside.write_text("secret")
+        os.symlink(outside, base / "escape.md")
+
+        assert resolve_contained_path(base, base / "escape.md") is None
+        assert resolve_contained_path(base, base / ".." / "outside.md") is None
+
+    def test_resolved_contained_path_fails_closed(self):
+        from mcp_tools import resolve_contained_path
+
+        assert resolve_contained_path(None, None) is None
+
+
+class TestReaderRefusesToFollowLinks:
+    """Resolving before opening is necessary but not sufficient.
+
+    A path that is a regular file when checked can be replaced by a symlink
+    before it is opened, and the open follows it. Resolving first does not help
+    -- a regular file resolves to itself. Only refusing to follow a link at open
+    time closes that window, because the refusal is part of the open itself.
+    """
+
+    def test_reader_refuses_a_symlink(self, tmp_path):
+        from mcp_tools import clear_caches, get_file_content_cached
+
+        secret = tmp_path / "secret.md"
+        secret.write_text("TOCTOU-CANARY-7712")
+        link = tmp_path / "link.md"
+        os.symlink(secret, link)
+
+        clear_caches()
+        content = get_file_content_cached(str(link))
+
+        assert "TOCTOU-CANARY-7712" not in content, "followed a symlink at open time"
+
+    def test_reader_still_reads_regular_files(self, tmp_path):
+        from mcp_tools import clear_caches, get_file_content_cached
+
+        regular = tmp_path / "regular.md"
+        regular.write_text("# Regular\n\nordinary content")
+
+        clear_caches()
+        content = get_file_content_cached(str(regular))
+
+        assert "ordinary content" in content

--- a/tests/unit/test_containment_consistency.py
+++ b/tests/unit/test_containment_consistency.py
@@ -1,0 +1,191 @@
+"""Every path that touches a documentation file must agree on containment.
+
+`read_laravel_doc_content` refuses a file that resolves outside its version
+directory. The enumeration paths -- listing and searching -- did not check at
+all, so the same symlinked file was denied on read while being listed and
+match-counted. That disagreement is a content oracle over material the read
+path explicitly refuses to serve.
+"""
+
+import os
+
+import pytest
+
+from mcp_tools import (
+    SUPPORTED_VERSIONS,
+    list_laravel_docs_impl,
+    read_laravel_doc_content_impl,
+    search_laravel_docs_impl,
+    search_laravel_docs_with_context_impl,
+)
+
+# The term searched for. It is echoed back in "no results" messages, so it
+# cannot double as the leak canary.
+QUERY = "OUTSIDE-CANARY-content"
+# Text that only ever appears inside the out-of-tree file. Its presence in any
+# response means real content escaped, not just the query being echoed.
+PAYLOAD = "SENSITIVE-PAYLOAD-4417"
+VERSION = SUPPORTED_VERSIONS[-1]
+
+
+@pytest.fixture
+def docs_with_escaping_symlink(tmp_path):
+    """A version directory containing a symlink that points outside the tree."""
+    docs = tmp_path / "docs"
+    version_dir = docs / VERSION
+    version_dir.mkdir(parents=True)
+    (version_dir / "blade.md").write_text("# Blade\n\nLegitimate content.")
+
+    outside = tmp_path / "outside.md"
+    outside.write_text(f"# Secret\n\n{QUERY} {PAYLOAD}")
+    os.symlink(outside, version_dir / "routing.md")
+
+    return docs
+
+
+def test_read_refuses_the_escaping_symlink(docs_with_escaping_symlink):
+    """Baseline: this is the behavior the other paths must match."""
+    result = read_laravel_doc_content_impl(docs_with_escaping_symlink, "routing.md", VERSION)
+
+    assert PAYLOAD not in result
+    assert "Access denied" in result
+
+
+def test_list_does_not_advertise_the_escaping_symlink(docs_with_escaping_symlink):
+    result = list_laravel_docs_impl(docs_with_escaping_symlink, version=VERSION)
+
+    assert "routing.md" not in result, "listed a file that read refuses to serve"
+    assert "blade.md" in result, "legitimate files must still be listed"
+
+
+def test_search_does_not_match_inside_the_escaping_symlink(docs_with_escaping_symlink):
+    result = search_laravel_docs_impl(
+        docs_with_escaping_symlink, QUERY, version=VERSION, include_external=False
+    )
+
+    assert "routing.md" not in result, "match-counted a file that read refuses to serve"
+
+
+def test_context_search_does_not_leak_the_escaping_symlink(docs_with_escaping_symlink):
+    result = search_laravel_docs_with_context_impl(
+        docs_with_escaping_symlink, QUERY, version=VERSION, include_external=False
+    )
+
+    assert PAYLOAD not in result, "leaked content that read refuses to serve"
+    assert "routing.md" not in result
+
+
+def test_legitimate_search_still_works(docs_with_escaping_symlink):
+    """The containment filter must not break ordinary searching."""
+    result = search_laravel_docs_impl(
+        docs_with_escaping_symlink, "Legitimate", version=VERSION, include_external=False
+    )
+
+    assert "blade.md" in result
+
+
+class TestAllowedHostWildcard:
+    """`ALLOWED_HOSTS=*` must not silently disable the Host guard.
+
+    FastMCP matches allowed hosts with fnmatchcase, so a wildcard entry matches
+    every Host header — turning off DNS-rebinding protection while the operator
+    sees a configured allowlist. Wildcard CORS origins are already rejected;
+    hosts were not.
+    """
+
+    def _parse(self, monkeypatch, argv, env):
+        import sys
+        from laravel_mcp_companion import parse_arguments
+
+        for var in ("CORS_ORIGINS", "ALLOWED_HOSTS"):
+            monkeypatch.delenv(var, raising=False)
+        for key, value in env.items():
+            monkeypatch.setenv(key, value)
+        monkeypatch.setattr(sys, "argv", ["prog"] + argv)
+        return parse_arguments()
+
+    @pytest.mark.parametrize("wildcard", ["*", "*.example.com", "foo*"])
+    def test_wildcard_host_is_rejected_from_cli(self, monkeypatch, wildcard):
+        with pytest.raises(SystemExit):
+            self._parse(monkeypatch, ["--allowed-host", wildcard], {})
+
+    def test_wildcard_host_is_rejected_from_env(self, monkeypatch):
+        """The env path must be checked too; argparse does not validate defaults."""
+        with pytest.raises(SystemExit):
+            self._parse(monkeypatch, [], {"ALLOWED_HOSTS": "good.example,*"})
+
+    def test_literal_hosts_are_accepted(self, monkeypatch):
+        args = self._parse(
+            monkeypatch, ["--allowed-host", "mcp.internal.example"], {}
+        )
+        assert args.allowed_host == ["mcp.internal.example"]
+
+
+class TestLearningResourceSymlinkConsistency:
+    """Scoped and unscoped learning-resource access must give the same answer.
+
+    `validate_subdirectory` resolves through symlinks, so a symlinked source was
+    reported "not found" while simultaneously appearing in the available-sources
+    list, and an unscoped search read it anyway. Whichever answer is right, all
+    three paths have to give it.
+    """
+
+    @pytest.fixture
+    def learning_with_symlinked_source(self, tmp_path):
+        docs = tmp_path / "docs"
+        learning = docs / "learning_resources"
+        learning.mkdir(parents=True)
+
+        # A real source, and one relocated elsewhere via symlink
+        (learning / "tutorials").mkdir()
+        (learning / "tutorials" / "intro.md").write_text("# Intro\n\nreal source")
+
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        (elsewhere / "guide.md").write_text(f"# Guide\n\n{PAYLOAD}")
+        os.symlink(elsewhere, learning / "bootcamp")
+
+        return docs
+
+    def test_listing_a_source_agrees_with_listing_all(self, learning_with_symlinked_source):
+        from mcp_tools import list_laravel_learning_resources_impl
+
+        all_sources = list_laravel_learning_resources_impl(learning_with_symlinked_source)
+        scoped = list_laravel_learning_resources_impl(
+            learning_with_symlinked_source, source="bootcamp"
+        )
+
+        advertised = "bootcamp" in all_sources
+        readable = "not found" not in scoped
+
+        assert advertised == readable, (
+            "a source listed as available must be readable, and vice versa; "
+            f"advertised={advertised} readable={readable}"
+        )
+
+    def test_search_agrees_with_listing(self, learning_with_symlinked_source):
+        from mcp_tools import (
+            list_laravel_learning_resources_impl,
+            search_laravel_learning_resources_impl,
+        )
+
+        all_sources = list_laravel_learning_resources_impl(learning_with_symlinked_source)
+        unscoped_search = search_laravel_learning_resources_impl(
+            learning_with_symlinked_source, PAYLOAD
+        )
+
+        advertised = "bootcamp" in all_sources
+        searched = "bootcamp" in unscoped_search
+
+        assert advertised == searched, (
+            "unscoped search must cover exactly the sources that are listed; "
+            f"advertised={advertised} searched={searched}"
+        )
+
+    def test_real_sources_are_unaffected(self, learning_with_symlinked_source):
+        from mcp_tools import list_laravel_learning_resources_impl
+
+        result = list_laravel_learning_resources_impl(
+            learning_with_symlinked_source, source="tutorials"
+        )
+        assert "intro.md" in result

--- a/tests/unit/test_laravel_mcp_tools.py
+++ b/tests/unit/test_laravel_mcp_tools.py
@@ -5,12 +5,12 @@ from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 import laravel_mcp_companion
+from mcp_tools import is_safe_path
 from docs_updater import DEFAULT_VERSION
 from laravel_mcp_companion import (
     search_by_use_case,
     format_package_recommendation,
     get_version_from_path,
-    is_safe_path,
     get_file_content_cached,
     clear_file_cache,
     setup_docs_path,

--- a/tests/unit/test_mcp_tool_functions.py
+++ b/tests/unit/test_mcp_tool_functions.py
@@ -104,28 +104,30 @@ class TestDocumentationTools:
         
         assert result == test_content
 
-    @patch('mcp_tools.get_file_content_cached')
-    @patch('mcp_tools.os.listdir')
-    def test_search_laravel_docs_success(self, mock_listdir, mock_get_content, test_docs_dir):
-        """Test searching Laravel documentation successfully returns TOON format."""
-        # Directory already exists from fixture
+    def test_search_laravel_docs_success(self, test_docs_dir):
+        """Test searching Laravel documentation successfully returns TOON format.
 
-        # Mock file listing
-        mock_listdir.return_value = ['routing.md', 'eloquent.md']
-
-        # Mock file content
-        mock_get_content.side_effect = [
-            "# Routing\n\nLaravel routing is awesome for web applications",
+        Uses real files rather than mocking the directory listing: enumeration
+        now applies a containment check, so a mocked listing no longer reflects
+        what the search actually reads.
+        """
+        version_dir = test_docs_dir / "12.x"
+        (version_dir / "routing.md").write_text(
+            "# Routing\n\nLaravel routing is awesome for web applications"
+        )
+        (version_dir / "eloquent.md").write_text(
             "# Eloquent\n\nEloquent ORM for database routing"
-        ]
+        )
 
         with patch('mcp_tools.SUPPORTED_VERSIONS', ['12.x']):
-            result = search_laravel_docs_impl(test_docs_dir, "routing", "12.x")
+            result = search_laravel_docs_impl(
+                test_docs_dir, "routing", "12.x", include_external=False
+            )
 
             # TOON format assertions
             assert "routing" in result
-            assert "12.x/routing.md" in result or "routing.md" in result
-            assert "12.x/eloquent.md" in result or "eloquent.md" in result
+            assert "routing.md" in result
+            assert "eloquent.md" in result
 
     def test_search_laravel_docs_empty_query(self, test_docs_dir):
         """Test searching with empty query."""
@@ -381,8 +383,8 @@ class TestMcpToolsEdgeCases:
         """Test list_laravel_docs handles exceptions gracefully."""
         from mcp_tools import list_laravel_docs_impl
 
-        with patch('mcp_tools.os.listdir') as mock_listdir:
-            mock_listdir.side_effect = OSError("Permission denied")
+        with patch('mcp_tools.os.scandir') as mock_scandir:
+            mock_scandir.side_effect = OSError("Permission denied")
 
             result = list_laravel_docs_impl(test_docs_dir, "12.x")
 
@@ -466,8 +468,8 @@ class TestMcpToolsEdgeCases:
         """Test search with context handles exceptions."""
         from mcp_tools import search_laravel_docs_with_context_impl
 
-        with patch('mcp_tools.os.listdir') as mock_listdir:
-            mock_listdir.side_effect = Exception("Search error")
+        with patch('mcp_tools.os.scandir') as mock_scandir:
+            mock_scandir.side_effect = Exception("Search error")
 
             with patch('mcp_tools.SUPPORTED_VERSIONS', ['12.x']):
                 result = search_laravel_docs_with_context_impl(

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -4,7 +4,8 @@ import pytest
 from pathlib import Path
 from unittest.mock import patch
 
-from laravel_mcp_companion import is_safe_path, get_version_from_path
+from laravel_mcp_companion import get_version_from_path
+from mcp_tools import is_safe_path
 import laravel_mcp_companion
 
 


### PR DESCRIPTION
Closes the three security findings left open from the adversarial review. Each was driven by a failing test written **before** the fix — every RED was watched and confirmed to fail for the right reason.

## 1. Enumeration skipped the containment check that reading applies

A symlink inside a version directory pointing outside the tree, exercised three ways on `main`:

```
read  : Access denied     ← correct
list  : routing.md listed ← advertised anyway
search: match counted     ← and the context search returned the content outright
```

Three code paths, two answers. That disagreement is an oracle over material the read path deliberately withholds — and the context variant didn't just leak a count, it returned the surrounding text.

`list_laravel_docs`, `search_laravel_docs`, and `search_laravel_docs_with_context` now enumerate through one helper that applies the same rule as reading. After:

```
read  : denied ✅   list  : excluded ✅   search: excluded ✅
```

**The helper deliberately does not swallow errors.** My first version caught `OSError` and returned an empty list — which would have reported an unreadable documentation directory as "no files found". That's the same silent-failure pattern this project has spent two days removing. Errors propagate; the callers already turn them into a message. Two existing tests caught this, which is why they're worth keeping.

## 2. `ALLOWED_HOSTS` accepted wildcards

FastMCP matches allowed hosts with `fnmatchcase`, so `ALLOWED_HOSTS=*` matches every `Host` header and disables DNS-rebinding protection — while presenting to the operator as a configured allowlist. Wildcard CORS origins were already rejected (`laravel_mcp_companion.py:2348`); hosts were passed straight through.

Now rejected on both the flag and the environment path, with an error that says why rather than just refusing.

## 3. Learning-resource sources contradicted themselves

`validate_subdirectory` resolved through symlinks, so a relocated source was reported **not found** when asked for directly, while simultaneously appearing in `available_sources` and being read by unscoped search.

Resolved the same way as `DocsUpdater` version directories: compare the parent, not the resolved path. An operator-placed *directory* symlink is a legitimate deployment choice; an escaping *file* inside one is not. The name checks already guarantee a single path component, so this cannot traverse — confirmed by the 80 existing traversal regression tests, which still pass.

## Test plan

- [x] **604 tests pass** (was 596); ruff and mypy clean across 37 files; coverage 66.75%
- [x] 13 new tests, each written and watched to fail first
- [x] All 80 path-traversal regression tests still pass — the symlink relaxation in #3 does not reopen `source="../../private"`
- [x] Re-ran the original three-way inconsistency and confirmed all paths now agree

## Test-quality note

One of my own tests was a false positive on the first run: it asserted the secret string didn't appear in the output, but the search echoes the *query* back in its "no results" message, so it failed even though nothing leaked. Split into a separate query term and a payload marker that only exists inside the out-of-tree file. Worth flagging because it's exactly the failure TDD is meant to catch — a test that fails for the wrong reason is as useless as one that passes for the wrong reason.

Two existing tests also mocked `os.listdir` to control enumeration; they now mock what's actually called, and the search happy-path test uses real files rather than canned contents — the coupling that let a mocked listing drift from what the code reads.

## What remains

The **TOCTOU** between `is_safe_path` and `open()` is untouched. The check resolves a path, discards the resolved value, and the caller opens the unresolved one; the reviewer won that race in 7 attempts. It needs local symlink-creation inside the docs tree, so it isn't remote, and the fix is a signature change (return the resolved path, or `O_NOFOLLOW`) that's worth doing on its own rather than bundled here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened documentation file access to prevent path traversal and unsafe symlink access.
  * Improved consistency between documentation listing, reading, and searching.
  * Rejected wildcard host allowlists to preserve explicit host validation and DNS-rebinding protection.

* **Bug Fixes**
  * Ensured contained relocated documentation directories remain accessible.
  * Prevented escaped symlinks from appearing in documentation results.

* **Tests**
  * Added comprehensive coverage for path containment, symlink handling, host validation, and documentation access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->