### PR TITLE
Rank documentation search by BM25 over sections, and add section reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,21 @@ docs-only commit and contains no code change.
 
 ## [Unreleased]
 
+### Breaking
+- `search_laravel_docs` returns ranked documentation *sections* with snippets and
+  anchors, rather than files with match counts, and
+  `search_laravel_docs_with_context` is removed. Both matched the query as a
+  literal substring, so four of seven realistic developer questions returned
+  nothing at all; ranking by raw match count also placed `queues.md` 13th of 24
+  for "queues", behind a file with a single match. An exact-symbol query such as
+  `queue:retry` still works, via a substring fallback.
+
+### Added
+- `read_laravel_doc_section` reads one section by anchor or heading, as returned
+  by search. Answering "how do I retry a failed queue job" end to end now costs
+  about 3,200 tokens against roughly 34,000 for the whole-file path — `queues.md`
+  alone is 34,048 tokens, and a quarter of the files exceed 10,000.
+
 ### Changed
 - Documentation syncs are tagged `docs-YYYY-MM-DD` instead of incrementing the
   patch version, and no longer publish a GitHub Release. Version numbers now

--- a/README.md
+++ b/README.md
@@ -204,6 +204,12 @@ Requests with an unrecognized `Host` get `421`; requests from an unlisted `Origi
 - **Related resources** - Find connected documentation automatically
 
 ### Search & Navigation
+- **Ranked section search** - Ask in plain language ("how do I retry a failed
+  queue job") and get the relevant *sections* ranked by relevance, each with a
+  snippet and an anchor
+- **Section-level reads** - Fetch just the section you need. A whole
+  documentation file can exceed 30,000 tokens; a section is typically a few
+  hundred, so answers leave room for your actual code
 - **Use case mapping** - Describe what you need, get relevant packages
 - **Package integration guides** - Installation and setup for 50+ packages
 - **Cross-package compatibility** - Documentation for package combinations

--- a/doc_search.py
+++ b/doc_search.py
@@ -7,8 +7,11 @@ MCP tool layer, and so mcp_tools does not grow further.
 
 import math
 import re
+import threading
+from collections import OrderedDict
 from dataclasses import dataclass
-from typing import Optional
+from pathlib import Path
+from typing import Callable, Optional
 
 # Consumes the closing </a> so that "is anything after this anchor?" is answered
 # about the document, not about the tag's own second half.
@@ -191,3 +194,78 @@ def extract_snippet(text: str, query: str, max_chars: int = 300) -> str:
     if end < len(body):
         snippet = snippet + "..."
     return snippet
+
+
+MAX_RESIDENT_INDEXES = 2
+
+_registry: "OrderedDict[str, DocIndex]" = OrderedDict()
+_registry_lock = threading.Lock()
+
+
+class DocIndex:
+    """A BM25 index over the sections of one version or service."""
+
+    def __init__(self, sections: list[Section]) -> None:
+        self.sections = sections
+        self._index = BM25Index()
+        self._index.build([s.text for s in sections])
+
+    def search(self, query: str, top_k: int) -> list[tuple[Section, float]]:
+        return [
+            (self.sections[i], score) for i, score in self._index.query(query, top_k)
+        ]
+
+    def substring_search(self, query: str, top_k: int) -> list[tuple[Section, float]]:
+        """Literal fallback, preserving exact-symbol lookup such as `queue:retry`.
+
+        BM25 tokenizes on alphanumerics, so a punctuated symbol is split into
+        parts that may rank poorly. This is the one thing the previous substring
+        implementation did well, and it would otherwise be lost.
+        """
+        needle = query.lower()
+        hits = [
+            (section, float(section.text.lower().count(needle)))
+            for section in self.sections
+            if needle in section.text.lower()
+        ]
+        hits.sort(key=lambda pair: pair[1], reverse=True)
+        return hits[:top_k]
+
+
+def get_index(
+    docs_path: Path, key: str, loader: Callable[[], list[Section]]
+) -> DocIndex:
+    """Return the index for `key`, building it on first use.
+
+    Indexes cost roughly 13 MB each, so only MAX_RESIDENT_INDEXES are kept and
+    the least recently used is dropped. Rebuilding costs about 100 ms, which is
+    the right trade for a bounded footprint given search defaults to a single
+    version.
+    """
+    with _registry_lock:
+        existing = _registry.get(key)
+        if existing is not None:
+            _registry.move_to_end(key)
+            return existing
+
+    # Built outside the lock: loading and indexing is slow and must not block
+    # other lookups.
+    index = DocIndex(loader())
+
+    with _registry_lock:
+        _registry[key] = index
+        _registry.move_to_end(key)
+        while len(_registry) > MAX_RESIDENT_INDEXES:
+            _registry.popitem(last=False)
+    return index
+
+
+def clear_indexes() -> None:
+    """Drop every resident index. Called when documentation is updated."""
+    with _registry_lock:
+        _registry.clear()
+
+
+def resident_index_count() -> int:
+    with _registry_lock:
+        return len(_registry)

--- a/doc_search.py
+++ b/doc_search.py
@@ -148,3 +148,46 @@ class BM25Index:
 
         ranked = sorted(range(self._n), key=lambda i: scores[i], reverse=True)
         return [(i, scores[i]) for i in ranked[:top_k] if scores[i] > 0]
+
+
+def extract_snippet(text: str, query: str, max_chars: int = 300) -> str:
+    """Return a readable window of `text` around the best query-term match.
+
+    Aligns to line boundaries so the result reads as prose rather than a
+    mid-word slice. Falls back to the start of the section when no query term
+    appears, which happens when a section matched on terms that the snippet
+    window did not reach.
+    """
+    body = text.strip()
+    if len(body) <= max_chars:
+        return body
+
+    lowered = body.lower()
+    position = -1
+    for term in sorted(tokenize(query), key=len, reverse=True):
+        position = lowered.find(term)
+        if position != -1:
+            break
+
+    if position == -1:
+        window = body[:max_chars]
+        return (window.rsplit("\n", 1)[0].strip() or window.strip()) + "..."
+
+    start = max(0, position - max_chars // 2)
+    end = min(len(body), start + max_chars)
+
+    if start > 0:
+        newline = body.find("\n", start)
+        if newline != -1 and newline < position:
+            start = newline + 1
+    if end < len(body):
+        newline = body.rfind("\n", start, end)
+        if newline != -1 and newline > position:
+            end = newline
+
+    snippet = body[start:end].strip()
+    if start > 0:
+        snippet = "..." + snippet
+    if end < len(body):
+        snippet = snippet + "..."
+    return snippet

--- a/doc_search.py
+++ b/doc_search.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Section-level chunking, BM25 indexing and retrieval for Laravel documentation.
+
+Kept separate from mcp_tools so chunking and scoring can be tested without the
+MCP tool layer, and so mcp_tools does not grow further.
+"""
+
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+# Consumes the closing </a> so that "is anything after this anchor?" is answered
+# about the document, not about the tag's own second half.
+_ANCHOR = re.compile(r'<a\s+name="([^"]+)"\s*>\s*(?:</a>)?')
+_H2_SPLIT = re.compile(r"\n(?=##\s)")
+
+
+@dataclass(frozen=True)
+class Section:
+    """One ## section of a documentation file."""
+
+    version: str
+    filename: str
+    anchor: Optional[str]
+    heading: str
+    text: str
+
+
+def chunk_markdown(text: str, filename: str, version: str) -> list[Section]:
+    """Split a markdown document into ## sections.
+
+    Chunking at ## was measured as the most robust retrieval unit. Finer
+    granularity produced sharper hits on some queries but regressed on others,
+    because short chunks give BM25 too few terms to discriminate.
+
+    The preamble before the first ## is kept as its own section so content at
+    the top of a file stays reachable.
+
+    Anchors in Laravel's documentation sit on the line *before* their heading,
+    so after splitting they land at the end of the preceding chunk and are
+    carried forward to the section they actually label.
+    """
+    parts = [p for p in _H2_SPLIT.split(text) if p.strip()]
+    sections: list[Section] = []
+    carried_anchor: Optional[str] = None
+
+    for part in parts:
+        heading_match = re.match(r"##\s+(.+)", part.lstrip())
+        if heading_match:
+            heading = heading_match.group(1).strip()
+        else:
+            title = re.match(r"#\s+(.+)", part.lstrip())
+            heading = title.group(1).strip() if title else filename
+
+        anchors = list(_ANCHOR.finditer(part))
+
+        # An anchor with nothing after it labels the *next* section, so it is
+        # carried forward and must not be claimed as this section's own.
+        trailing: Optional[str] = None
+        if anchors and not part[anchors[-1].end():].strip():
+            trailing = anchors[-1].group(1)
+            anchors = anchors[:-1]
+
+        anchor = carried_anchor or (anchors[0].group(1) if anchors else None)
+        carried_anchor = trailing
+
+        sections.append(
+            Section(
+                version=version,
+                filename=filename,
+                anchor=anchor,
+                heading=heading,
+                text=part,
+            )
+        )
+
+    return sections

--- a/doc_search.py
+++ b/doc_search.py
@@ -179,13 +179,19 @@ def extract_snippet(text: str, query: str, max_chars: int = 300) -> str:
     start = max(0, position - max_chars // 2)
     end = min(len(body), start + max_chars)
 
+    # Trim to line boundaries, but only when doing so leaves a usable snippet.
+    # Laravel formats paragraphs as single long lines, so the nearest newline is
+    # often the one just after the heading -- snapping to it would return the
+    # heading alone and tell the reader nothing.
+    minimum = max_chars // 2
+
     if start > 0:
         newline = body.find("\n", start)
-        if newline != -1 and newline < position:
+        if newline != -1 and newline < position and end - (newline + 1) >= minimum:
             start = newline + 1
     if end < len(body):
         newline = body.rfind("\n", start, end)
-        if newline != -1 and newline > position:
+        if newline != -1 and newline > position and newline - start >= minimum:
             end = newline
 
     snippet = body[start:end].strip()

--- a/doc_search.py
+++ b/doc_search.py
@@ -5,6 +5,7 @@ Kept separate from mcp_tools so chunking and scoring can be tested without the
 MCP tool layer, and so mcp_tools does not grow further.
 """
 
+import math
 import re
 from dataclasses import dataclass
 from typing import Optional
@@ -75,3 +76,75 @@ def chunk_markdown(text: str, filename: str, version: str) -> list[Section]:
         )
 
     return sections
+
+
+_TOKEN = re.compile(r"[a-z0-9]+")
+
+BM25_K1 = 1.5
+BM25_B = 0.75
+
+
+def tokenize(text: str) -> list[str]:
+    """Lowercase alphanumeric tokens."""
+    return _TOKEN.findall(text.lower())
+
+
+class BM25Index:
+    """Okapi BM25 over a fixed document set.
+
+    Owned rather than imported. fastmcp ships an equivalent, but it is a private
+    underscore-prefixed class in a fast-moving dependency, and it retains its
+    tokenized documents after building -- which is most of the memory cost. Only
+    term counts are kept here; the token lists go out of scope during build.
+    """
+
+    def __init__(self, k1: float = BM25_K1, b: float = BM25_B) -> None:
+        self.k1 = k1
+        self.b = b
+        self._n = 0
+        self._avg_dl = 0.0
+        self._lengths: list[int] = []
+        self._df: dict[str, int] = {}
+        self._tf: list[dict[str, int]] = []
+
+    def build(self, documents: list[str]) -> None:
+        self._n = len(documents)
+        self._lengths = []
+        self._df = {}
+        self._tf = []
+
+        for doc in documents:
+            tokens = tokenize(doc)
+            self._lengths.append(len(tokens))
+            tf: dict[str, int] = {}
+            for token in tokens:
+                tf[token] = tf.get(token, 0) + 1
+            self._tf.append(tf)
+            for token in tf:
+                self._df[token] = self._df.get(token, 0) + 1
+            # `tokens` is released here; only counts are retained.
+
+        self._avg_dl = (sum(self._lengths) / self._n) if self._n else 0.0
+
+    def query(self, text: str, top_k: int) -> list[tuple[int, float]]:
+        """Return (document_index, score) pairs, best first, omitting zero scores."""
+        terms = tokenize(text)
+        if not terms or not self._n:
+            return []
+
+        scores = [0.0] * self._n
+        for term in terms:
+            df = self._df.get(term)
+            if not df:
+                continue
+            idf = math.log((self._n - df + 0.5) / (df + 0.5) + 1.0)
+            for i, tf_map in enumerate(self._tf):
+                tf = tf_map.get(term, 0)
+                if not tf:
+                    continue
+                dl = self._lengths[i]
+                denom = tf + self.k1 * (1 - self.b + self.b * dl / self._avg_dl)
+                scores[i] += idf * tf * (self.k1 + 1) / denom
+
+        ranked = sorted(range(self._n), key=lambda i: scores[i], reverse=True)
+        return [(i, scores[i]) for i in ranked[:top_k] if scores[i] > 0]

--- a/docs/superpowers/plans/2026-07-31-chunked-bm25-retrieval.md
+++ b/docs/superpowers/plans/2026-07-31-chunked-bm25-retrieval.md
@@ -1,0 +1,1337 @@
+# Chunked BM25 Retrieval Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace substring documentation search with BM25 ranking over heading-level sections, and add a tool to read a single section, so a natural-language question returns a ranked snippet for hundreds of tokens instead of nothing or a whole 34,000-token file.
+
+**Architecture:** A new `doc_search.py` module owns chunking, a ~40-line Okapi BM25 index, and a lazy per-version index registry capped at two resident indexes. `mcp_tools.py` delegates to it; the tool layer in `laravel_mcp_companion.py` keeps the `search_laravel_docs` name with a new result shape, adds `read_laravel_doc_section`, and drops the redundant `search_laravel_docs_with_context`.
+
+**Tech Stack:** Python 3.12, pytest, FastMCP 3.4.5, TOON output via `toon_helpers`.
+
+## Global Constraints
+
+- Python >= 3.12 (`pyproject.toml`); CI installs 3.12 explicitly.
+- Chunk on `##` headings only. Finer granularity measured worse (4/4 correct at `##`, 2/4 at `###` and at anchors).
+- BM25 parameters: k1=1.5, b=0.75.
+- Own the BM25 index. Do not import `fastmcp.server.transforms.search.bm25._BM25Index` — it is a private class and retains token lists after build.
+- At most 2 indexes resident, LRU-evicted.
+- Index registry must be cleared by the existing `mcp_tools.clear_caches()`.
+- All file reads go through `mcp_tools.get_file_content_cached` and enumeration through `mcp_tools.list_contained_markdown`, preserving containment and O_NOFOLLOW behaviour. Do not open files directly.
+- Version arguments validate via `mcp_tools.validate_version`; path joins validate via `mcp_tools.resolve_contained_path`.
+- Errors from unreadable directories propagate; they are not converted to "no files found".
+- Run tests with `.venv/bin/python -m pytest`. Ruff and mypy must stay clean.
+- Commit with `git lc` (wrapper handles the repo's commit-time policy), never plain `git commit`.
+
+---
+
+### Task 1: Section chunking
+
+**Files:**
+- Create: `doc_search.py`
+- Test: `tests/unit/test_doc_search.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `Section` dataclass with fields `version: str`, `filename: str`, `anchor: str | None`, `heading: str`, `text: str`; and `chunk_markdown(text: str, filename: str, version: str) -> list[Section]`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_doc_search.py
+from doc_search import Section, chunk_markdown
+
+SAMPLE = """# Queues
+
+Intro paragraph before any section.
+
+<a name="dealing-with-failed-jobs"></a>
+## Dealing With Failed Jobs
+
+Jobs that exceed max attempts land in failed_jobs.
+
+## Max Job Attempts
+
+Use the tries property.
+"""
+
+
+def test_chunk_splits_on_h2_headings():
+    sections = chunk_markdown(SAMPLE, "queues.md", "13.x")
+    headings = [s.heading for s in sections]
+    assert "Dealing With Failed Jobs" in headings
+    assert "Max Job Attempts" in headings
+
+
+def test_chunk_captures_anchor_when_present():
+    sections = chunk_markdown(SAMPLE, "queues.md", "13.x")
+    failed = next(s for s in sections if s.heading == "Dealing With Failed Jobs")
+    assert failed.anchor == "dealing-with-failed-jobs"
+
+
+def test_chunk_leaves_anchor_none_when_absent():
+    sections = chunk_markdown(SAMPLE, "queues.md", "13.x")
+    attempts = next(s for s in sections if s.heading == "Max Job Attempts")
+    assert attempts.anchor is None
+
+
+def test_chunk_keeps_preamble_before_first_heading():
+    sections = chunk_markdown(SAMPLE, "queues.md", "13.x")
+    assert any("Intro paragraph" in s.text for s in sections)
+
+
+def test_chunk_file_with_no_h2_returns_one_section():
+    sections = chunk_markdown("# Title\n\nBody only.\n", "solo.md", "13.x")
+    assert len(sections) == 1
+    assert "Body only." in sections[0].text
+
+
+def test_chunk_records_provenance():
+    sections = chunk_markdown(SAMPLE, "queues.md", "13.x")
+    assert all(s.filename == "queues.md" for s in sections)
+    assert all(s.version == "13.x" for s in sections)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_doc_search.py -q --no-cov`
+Expected: FAIL with `ModuleNotFoundError: No module named 'doc_search'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# doc_search.py
+"""Section-level chunking, BM25 indexing and retrieval for Laravel documentation.
+
+Kept separate from mcp_tools so that chunking and scoring can be tested without
+the MCP tool layer, and so mcp_tools does not grow further.
+"""
+
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+_ANCHOR = re.compile(r'<a\s+name="([^"]+)"\s*>')
+_H2_SPLIT = re.compile(r"\n(?=##\s)")
+
+
+@dataclass(frozen=True)
+class Section:
+    """One ## section of a documentation file."""
+
+    version: str
+    filename: str
+    anchor: Optional[str]
+    heading: str
+    text: str
+
+
+def chunk_markdown(text: str, filename: str, version: str) -> list[Section]:
+    """Split a markdown document into ## sections.
+
+    Chunking at ## was measured as the most robust retrieval unit: finer
+    granularity produced sharper hits on some queries but regressed on others,
+    because short chunks give BM25 too few terms to discriminate.
+
+    The preamble before the first ## is kept as its own section so that content
+    at the top of a file is still reachable.
+    """
+    sections: list[Section] = []
+    for part in _H2_SPLIT.split(text):
+        if not part.strip():
+            continue
+
+        heading_match = re.match(r"##\s+(.+)", part.lstrip())
+        heading = heading_match.group(1).strip() if heading_match else ""
+        if not heading:
+            title = re.match(r"#\s+(.+)", part.lstrip())
+            heading = title.group(1).strip() if title else filename
+
+        anchor_match = _ANCHOR.search(part)
+        anchor = anchor_match.group(1) if anchor_match else None
+
+        sections.append(
+            Section(
+                version=version,
+                filename=filename,
+                anchor=anchor,
+                heading=heading,
+                text=part,
+            )
+        )
+    return sections
+```
+
+Note: the anchor for a section usually sits on the line *before* its `##`, so after
+splitting on `\n(?=##\s)` the anchor lands at the end of the *previous* chunk. Fix
+this by scanning for a trailing anchor on the preceding part and attaching it to the
+next section. Implement that in Step 3 as follows, replacing the loop body above:
+
+```python
+def chunk_markdown(text: str, filename: str, version: str) -> list[Section]:
+    parts = [p for p in _H2_SPLIT.split(text) if p.strip()]
+    sections: list[Section] = []
+    carried_anchor: Optional[str] = None
+
+    for part in parts:
+        heading_match = re.match(r"##\s+(.+)", part.lstrip())
+        if heading_match:
+            heading = heading_match.group(1).strip()
+        else:
+            title = re.match(r"#\s+(.+)", part.lstrip())
+            heading = title.group(1).strip() if title else filename
+
+        own_anchor = _ANCHOR.search(part)
+        anchor = carried_anchor or (own_anchor.group(1) if own_anchor else None)
+
+        trailing = list(_ANCHOR.finditer(part))
+        carried_anchor = None
+        if trailing:
+            last = trailing[-1]
+            if not part[last.end():].strip():
+                carried_anchor = last.group(1)
+
+        sections.append(
+            Section(version=version, filename=filename, anchor=anchor,
+                    heading=heading, text=part)
+        )
+    return sections
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_doc_search.py -q --no-cov`
+Expected: PASS, 6 tests
+
+- [ ] **Step 5: Verify against real documentation**
+
+Run:
+
+```bash
+.venv/bin/python -c "
+from pathlib import Path
+from doc_search import chunk_markdown
+t = Path('docs/13.x/queues.md').read_text()
+s = chunk_markdown(t, 'queues.md', '13.x')
+print(len(s), 'sections')
+print([x.heading for x in s][:4])
+print('anchored:', sum(1 for x in s if x.anchor), '/', len(s))
+"
+```
+
+Expected: about 14 sections, headings that read like real headings, and most sections carrying an anchor.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add doc_search.py tests/unit/test_doc_search.py
+git lc -m "Add section-level markdown chunking for documentation search"
+```
+
+---
+
+### Task 2: BM25 index
+
+**Files:**
+- Modify: `doc_search.py`
+- Test: `tests/unit/test_doc_search.py`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces: `BM25Index` with `build(documents: list[str]) -> None` and `query(text: str, top_k: int) -> list[tuple[int, float]]` returning `(document_index, score)` pairs sorted by descending score, excluding zero scores.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/unit/test_doc_search.py
+from doc_search import BM25Index
+
+CORPUS = [
+    "queue jobs are processed by workers and can fail",
+    "failed jobs are stored in the failed_jobs table and can be retried",
+    "blade templates render views with directives",
+]
+
+
+def test_index_ranks_the_relevant_document_first():
+    idx = BM25Index()
+    idx.build(CORPUS)
+    ranked = idx.query("retry failed jobs", top_k=3)
+    assert ranked, "expected at least one hit"
+    assert ranked[0][0] == 1
+
+
+def test_index_returns_scores_in_descending_order():
+    idx = BM25Index()
+    idx.build(CORPUS)
+    scores = [score for _, score in idx.query("jobs", top_k=3)]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_index_returns_nothing_for_unknown_terms():
+    idx = BM25Index()
+    idx.build(CORPUS)
+    assert idx.query("kubernetes helm chart", top_k=3) == []
+
+
+def test_index_handles_empty_corpus():
+    idx = BM25Index()
+    idx.build([])
+    assert idx.query("anything", top_k=3) == []
+
+
+def test_index_respects_top_k():
+    idx = BM25Index()
+    idx.build(CORPUS)
+    assert len(idx.query("jobs", top_k=1)) <= 1
+
+
+def test_index_releases_token_lists_after_build():
+    """Retaining tokenized documents is the bulk of the memory cost."""
+    idx = BM25Index()
+    idx.build(CORPUS)
+    assert not hasattr(idx, "_doc_tokens") or not idx._doc_tokens
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_doc_search.py -q --no-cov -k index`
+Expected: FAIL with `ImportError: cannot import name 'BM25Index'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# add to doc_search.py
+import math
+
+_TOKEN = re.compile(r"[a-z0-9]+")
+
+BM25_K1 = 1.5
+BM25_B = 0.75
+
+
+def tokenize(text: str) -> list[str]:
+    return _TOKEN.findall(text.lower())
+
+
+class BM25Index:
+    """Okapi BM25 over a fixed document set.
+
+    Owned rather than imported. fastmcp ships an equivalent, but it is a private
+    class in a fast-moving dependency and retains its tokenized documents after
+    building, which is most of the memory cost.
+    """
+
+    def __init__(self, k1: float = BM25_K1, b: float = BM25_B) -> None:
+        self.k1 = k1
+        self.b = b
+        self._n = 0
+        self._avg_dl = 0.0
+        self._lengths: list[int] = []
+        self._df: dict[str, int] = {}
+        self._tf: list[dict[str, int]] = []
+
+    def build(self, documents: list[str]) -> None:
+        self._n = len(documents)
+        self._lengths = []
+        self._df = {}
+        self._tf = []
+
+        for doc in documents:
+            tokens = tokenize(doc)
+            self._lengths.append(len(tokens))
+            tf: dict[str, int] = {}
+            for token in tokens:
+                tf[token] = tf.get(token, 0) + 1
+            self._tf.append(tf)
+            for token in tf:
+                self._df[token] = self._df.get(token, 0) + 1
+            # tokens goes out of scope here; only counts are retained
+
+        self._avg_dl = (sum(self._lengths) / self._n) if self._n else 0.0
+
+    def query(self, text: str, top_k: int) -> list[tuple[int, float]]:
+        terms = tokenize(text)
+        if not terms or not self._n:
+            return []
+
+        scores = [0.0] * self._n
+        for term in terms:
+            df = self._df.get(term)
+            if not df:
+                continue
+            idf = math.log((self._n - df + 0.5) / (df + 0.5) + 1.0)
+            for i, tf_map in enumerate(self._tf):
+                tf = tf_map.get(term, 0)
+                if not tf:
+                    continue
+                dl = self._lengths[i]
+                denom = tf + self.k1 * (1 - self.b + self.b * dl / self._avg_dl)
+                scores[i] += idf * tf * (self.k1 + 1) / denom
+
+        ranked = sorted(range(self._n), key=lambda i: scores[i], reverse=True)
+        return [(i, scores[i]) for i in ranked[:top_k] if scores[i] > 0]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_doc_search.py -q --no-cov`
+Expected: PASS, 12 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add doc_search.py tests/unit/test_doc_search.py
+git lc -m "Add owned BM25 index for documentation retrieval"
+```
+
+---
+
+### Task 3: Snippet extraction
+
+**Files:**
+- Modify: `doc_search.py`
+- Test: `tests/unit/test_doc_search.py`
+
+**Interfaces:**
+- Consumes: `tokenize` from Task 2.
+- Produces: `extract_snippet(text: str, query: str, max_chars: int = 300) -> str`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/unit/test_doc_search.py
+from doc_search import extract_snippet
+
+LONG = (
+    "Preamble line that is not relevant at all.\n"
+    + ("filler line\n" * 40)
+    + "Jobs that exceed their maximum attempts are inserted into the failed_jobs table.\n"
+    + ("more filler\n" * 40)
+)
+
+
+def test_snippet_centres_on_the_query_terms():
+    snippet = extract_snippet(LONG, "failed_jobs table", max_chars=200)
+    assert "failed_jobs" in snippet
+
+
+def test_snippet_respects_max_chars():
+    snippet = extract_snippet(LONG, "failed_jobs", max_chars=200)
+    assert len(snippet) <= 260  # allows for ellipsis markers
+
+
+def test_snippet_falls_back_to_the_start_when_no_term_matches():
+    snippet = extract_snippet(LONG, "kubernetes", max_chars=100)
+    assert snippet.startswith("Preamble")
+
+
+def test_snippet_of_short_text_returns_it_whole():
+    assert extract_snippet("short body", "body", max_chars=300) == "short body"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_doc_search.py -q --no-cov -k snippet`
+Expected: FAIL with `ImportError: cannot import name 'extract_snippet'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# add to doc_search.py
+def extract_snippet(text: str, query: str, max_chars: int = 300) -> str:
+    """Return a readable window of `text` around the best query-term match.
+
+    Aligns to line boundaries so the result reads as prose rather than a
+    mid-word slice.
+    """
+    body = text.strip()
+    if len(body) <= max_chars:
+        return body
+
+    lowered = body.lower()
+    position = -1
+    for term in sorted(tokenize(query), key=len, reverse=True):
+        position = lowered.find(term)
+        if position != -1:
+            break
+
+    if position == -1:
+        window = body[:max_chars]
+        return window.rsplit("\n", 1)[0].strip() or window.strip()
+
+    start = max(0, position - max_chars // 2)
+    end = min(len(body), start + max_chars)
+
+    if start > 0:
+        newline = body.find("\n", start)
+        if newline != -1 and newline < position:
+            start = newline + 1
+    if end < len(body):
+        newline = body.rfind("\n", start, end)
+        if newline != -1 and newline > position:
+            end = newline
+
+    snippet = body[start:end].strip()
+    if start > 0:
+        snippet = "..." + snippet
+    if end < len(body):
+        snippet = snippet + "..."
+    return snippet
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_doc_search.py -q --no-cov`
+Expected: PASS, 16 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add doc_search.py tests/unit/test_doc_search.py
+git lc -m "Add query-centred snippet extraction"
+```
+
+---
+
+### Task 4: Lazy per-version index registry with LRU cap
+
+**Files:**
+- Modify: `doc_search.py`
+- Test: `tests/unit/test_doc_search.py`
+
+**Interfaces:**
+- Consumes: `Section`, `chunk_markdown` (Task 1), `BM25Index` (Task 2).
+- Produces:
+  - `MAX_RESIDENT_INDEXES: int = 2`
+  - `DocIndex` with `sections: list[Section]` and `search(query: str, top_k: int) -> list[tuple[Section, float]]`
+  - `get_index(docs_path: Path, key: str, loader) -> DocIndex` where `loader() -> list[Section]`
+  - `clear_indexes() -> None`
+  - `resident_index_count() -> int`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/unit/test_doc_search.py
+from pathlib import Path
+
+from doc_search import (
+    DocIndex,
+    MAX_RESIDENT_INDEXES,
+    clear_indexes,
+    get_index,
+    resident_index_count,
+)
+
+
+def _sections(version, *bodies):
+    out = []
+    for i, body in enumerate(bodies):
+        out.extend(chunk_markdown(f"## Heading {i}\n\n{body}\n", f"f{i}.md", version))
+    return out
+
+
+def test_docindex_returns_sections_ranked():
+    index = DocIndex(_sections("13.x", "failed jobs are retried", "blade templates"))
+    hits = index.search("retry failed jobs", top_k=2)
+    assert hits
+    assert "failed jobs" in hits[0][0].text
+
+
+def test_get_index_builds_once_per_key():
+    clear_indexes()
+    calls = []
+
+    def loader():
+        calls.append(1)
+        return _sections("13.x", "queue workers")
+
+    get_index(Path("/unused"), "13.x", loader)
+    get_index(Path("/unused"), "13.x", loader)
+    assert len(calls) == 1
+
+
+def test_registry_evicts_beyond_the_cap():
+    clear_indexes()
+    for n in range(MAX_RESIDENT_INDEXES + 2):
+        get_index(Path("/unused"), f"v{n}", lambda: _sections("x", "content"))
+    assert resident_index_count() == MAX_RESIDENT_INDEXES
+
+
+def test_clear_indexes_empties_the_registry():
+    get_index(Path("/unused"), "13.x", lambda: _sections("13.x", "content"))
+    clear_indexes()
+    assert resident_index_count() == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_doc_search.py -q --no-cov -k "index or registry"`
+Expected: FAIL with `ImportError: cannot import name 'DocIndex'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# add to doc_search.py
+import threading
+from collections import OrderedDict
+from pathlib import Path
+from typing import Callable
+
+MAX_RESIDENT_INDEXES = 2
+
+_registry: "OrderedDict[str, DocIndex]" = OrderedDict()
+_registry_lock = threading.Lock()
+
+
+class DocIndex:
+    """A BM25 index over the sections of one version or service."""
+
+    def __init__(self, sections: list[Section]) -> None:
+        self.sections = sections
+        self._index = BM25Index()
+        self._index.build([s.text for s in sections])
+
+    def search(self, query: str, top_k: int) -> list[tuple[Section, float]]:
+        return [(self.sections[i], score) for i, score in self._index.query(query, top_k)]
+
+    def substring_search(self, query: str, top_k: int) -> list[tuple[Section, float]]:
+        """Literal fallback, preserving exact-symbol lookup such as `mimes:pdf`."""
+        needle = query.lower()
+        hits = [
+            (section, float(section.text.lower().count(needle)))
+            for section in self.sections
+            if needle in section.text.lower()
+        ]
+        hits.sort(key=lambda pair: pair[1], reverse=True)
+        return hits[:top_k]
+
+
+def get_index(docs_path: Path, key: str, loader: Callable[[], list[Section]]) -> DocIndex:
+    """Return the index for `key`, building it on first use.
+
+    Indexes are ~13 MB each, so only MAX_RESIDENT_INDEXES are kept; the least
+    recently used is dropped. Rebuilding costs about 100 ms.
+    """
+    with _registry_lock:
+        existing = _registry.get(key)
+        if existing is not None:
+            _registry.move_to_end(key)
+            return existing
+
+    index = DocIndex(loader())
+
+    with _registry_lock:
+        _registry[key] = index
+        _registry.move_to_end(key)
+        while len(_registry) > MAX_RESIDENT_INDEXES:
+            _registry.popitem(last=False)
+    return index
+
+
+def clear_indexes() -> None:
+    with _registry_lock:
+        _registry.clear()
+
+
+def resident_index_count() -> int:
+    with _registry_lock:
+        return len(_registry)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_doc_search.py -q --no-cov`
+Expected: PASS, 20 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add doc_search.py tests/unit/test_doc_search.py
+git lc -m "Add lazy per-version index registry with LRU cap"
+```
+
+---
+
+### Task 5: Wire the registry into cache invalidation
+
+**Files:**
+- Modify: `mcp_tools.py` (the `clear_caches` function)
+- Test: `tests/unit/test_doc_search.py`
+
+**Interfaces:**
+- Consumes: `clear_indexes`, `resident_index_count` (Task 4).
+- Produces: nothing new; `mcp_tools.clear_caches()` additionally clears the index registry.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/unit/test_doc_search.py
+def test_clear_caches_also_clears_indexes():
+    """Documentation updates call clear_caches; a stale index must not survive."""
+    from mcp_tools import clear_caches
+
+    get_index(Path("/unused"), "13.x", lambda: _sections("13.x", "content"))
+    assert resident_index_count() == 1
+
+    clear_caches()
+    assert resident_index_count() == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_doc_search.py -q --no-cov -k clear_caches`
+Expected: FAIL, `assert 1 == 0`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Find `def clear_caches` in `mcp_tools.py` and add the index clearing to it:
+
+```python
+def clear_caches() -> None:
+    """Clear file, search result, and documentation index caches."""
+    from doc_search import clear_indexes
+
+    with _cache_lock:
+        _file_content_cache.clear()
+        _search_result_cache.clear()
+    clear_indexes()
+    logger.info("Caches cleared")
+```
+
+The import is function-local to avoid a circular import: `doc_search` does not
+import `mcp_tools`, but Task 6 makes `mcp_tools` import `doc_search`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_doc_search.py -q --no-cov`
+Expected: PASS, 21 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_tools.py tests/unit/test_doc_search.py
+git lc -m "Clear documentation indexes when caches are cleared"
+```
+
+---
+
+### Task 6: Section loading from the documentation tree
+
+**Files:**
+- Modify: `mcp_tools.py`
+- Test: `tests/unit/test_doc_search.py`
+
+**Interfaces:**
+- Consumes: `Section`, `chunk_markdown` (Task 1); existing `list_contained_markdown` and `get_file_content_cached`.
+- Produces: `mcp_tools.load_version_sections(docs_path: Path, version: str) -> list[Section]` and `mcp_tools.load_service_sections(external_dir: Path, service: str) -> list[Section]`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/unit/test_doc_search.py
+def test_load_version_sections_reads_real_files(tmp_path):
+    from mcp_tools import SUPPORTED_VERSIONS, load_version_sections
+
+    version = SUPPORTED_VERSIONS[-1]
+    docs = tmp_path / "docs"
+    (docs / version).mkdir(parents=True)
+    (docs / version / "queues.md").write_text(
+        "# Queues\n\n## Failed Jobs\n\nRetry them with queue:retry.\n"
+    )
+
+    sections = load_version_sections(docs, version)
+
+    assert any(s.heading == "Failed Jobs" for s in sections)
+    assert all(s.filename == "queues.md" for s in sections)
+
+
+def test_load_version_sections_skips_escaping_symlinks(tmp_path):
+    """Containment behaviour must match the read path."""
+    import os
+
+    from mcp_tools import SUPPORTED_VERSIONS, load_version_sections
+
+    version = SUPPORTED_VERSIONS[-1]
+    docs = tmp_path / "docs"
+    (docs / version).mkdir(parents=True)
+    (docs / version / "real.md").write_text("## Real\n\ncontent\n")
+    outside = tmp_path / "outside.md"
+    outside.write_text("## Secret\n\nCANARY-9021\n")
+    os.symlink(outside, docs / version / "escape.md")
+
+    sections = load_version_sections(docs, version)
+
+    assert not any("CANARY-9021" in s.text for s in sections)
+
+
+def test_load_version_sections_of_missing_version_is_empty(tmp_path):
+    from mcp_tools import SUPPORTED_VERSIONS, load_version_sections
+
+    assert load_version_sections(tmp_path, SUPPORTED_VERSIONS[-1]) == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_doc_search.py -q --no-cov -k load_`
+Expected: FAIL with `ImportError: cannot import name 'load_version_sections'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# add to mcp_tools.py, after list_contained_markdown
+from doc_search import Section, chunk_markdown
+
+
+def load_version_sections(docs_path: Path, version: str) -> list[Section]:
+    """Chunk every contained markdown file of a version into sections.
+
+    Enumeration goes through list_contained_markdown and reads through
+    get_file_content_cached, so containment and the refusal to follow symlinks
+    at open time both carry over unchanged.
+    """
+    version_path = Path(docs_path) / version
+    if not version_path.is_dir():
+        return []
+
+    sections: list[Section] = []
+    for name, path in list_contained_markdown(version_path):
+        content = get_file_content_cached(str(path))
+        if content.startswith("Error") or content.startswith("File not found"):
+            continue
+        sections.extend(chunk_markdown(content, name, version))
+    return sections
+
+
+def load_service_sections(external_dir: Path, service: str) -> list[Section]:
+    """Chunk an external service's documentation, keyed by service name."""
+    service_path = Path(external_dir) / service
+    if not service_path.is_dir():
+        return []
+
+    sections: list[Section] = []
+    for name, path in list_contained_markdown(service_path):
+        content = get_file_content_cached(str(path))
+        if content.startswith("Error") or content.startswith("File not found"):
+            continue
+        sections.extend(chunk_markdown(content, name, service))
+    return sections
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_doc_search.py -q --no-cov`
+Expected: PASS, 24 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_tools.py tests/unit/test_doc_search.py
+git lc -m "Load documentation sections through the contained enumeration path"
+```
+
+---
+
+### Task 7: Replace search_laravel_docs_impl with ranked retrieval
+
+**Files:**
+- Modify: `mcp_tools.py` (replace the body of `search_laravel_docs_impl`)
+- Test: `tests/unit/test_retrieval_quality.py`
+
+**Interfaces:**
+- Consumes: `load_version_sections`, `load_service_sections` (Task 6); `get_index` (Task 4); `extract_snippet` (Task 3); existing `validate_version`, `resolve_search_versions`, `toon_encode`, `format_error`.
+- Produces: `search_laravel_docs_impl(docs_path, query, version=None, include_external=True, external_dir=None, runtime_version=None, all_versions=False, limit=5) -> str`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_retrieval_quality.py
+"""The retrieval regression this work exists to fix.
+
+Before: four of these seven questions returned nothing, because search matched
+the query as a literal substring.
+"""
+
+import pytest
+
+from mcp_tools import SUPPORTED_VERSIONS, search_laravel_docs_impl
+
+VERSION = SUPPORTED_VERSIONS[-1]
+DOCS = "docs"
+
+QUESTIONS = [
+    "how do I validate a file upload",
+    "retry failed queue job",
+    "send email with attachment",
+    "database transactions",
+    "rate limiting api routes",
+    "eloquent relationships",
+    "queue",
+]
+
+
+@pytest.mark.parametrize("question", QUESTIONS)
+def test_realistic_questions_return_results(question):
+    from pathlib import Path
+
+    result = search_laravel_docs_impl(
+        Path(DOCS), question, version=VERSION, include_external=False
+    )
+    assert "No results" not in result, f"{question!r} returned nothing"
+
+
+def test_ranking_prefers_the_relevant_file():
+    """queues.md ranked 13th of 24 for 'queues' under match-count ranking."""
+    from pathlib import Path
+
+    result = search_laravel_docs_impl(
+        Path(DOCS), "queue jobs and workers", version=VERSION, include_external=False
+    )
+    assert "queues.md" in result
+    first_line = [ln for ln in result.splitlines() if ".md" in ln][0]
+    assert "queues.md" in first_line
+
+
+def test_search_output_stays_within_budget():
+    """A search response must not drift back toward whole-file cost."""
+    from pathlib import Path
+
+    result = search_laravel_docs_impl(
+        Path(DOCS), "retry failed queue job", version=VERSION, include_external=False
+    )
+    assert len(result) < 4800, f"{len(result)} chars is over the ~1,200 token budget"
+
+
+def test_exact_symbol_lookup_falls_back_to_substring():
+    from pathlib import Path
+
+    result = search_laravel_docs_impl(
+        Path(DOCS), "queue:retry", version=VERSION, include_external=False
+    )
+    assert "No results" not in result
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_retrieval_quality.py -q --no-cov`
+Expected: FAIL — four of the seven parametrized cases assert "returned nothing", and the budget test fails.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace the whole body of `search_laravel_docs_impl` in `mcp_tools.py`:
+
+```python
+def search_laravel_docs_impl(
+    docs_path: Path,
+    query: str,
+    version: Optional[str] = None,
+    include_external: bool = True,
+    external_dir: Optional[Path] = None,
+    runtime_version: Optional[str] = None,
+    all_versions: bool = False,
+    limit: int = 5,
+) -> str:
+    """Search documentation, returning ranked sections with snippets.
+
+    Ranked by BM25 over ## sections rather than by literal substring count, so a
+    multi-word question matches and long files no longer outrank relevant ones.
+    """
+    from doc_search import extract_snippet, get_index
+
+    version_error = validate_version(version)
+    if version_error:
+        return version_error
+
+    if not query.strip():
+        return format_error("Search query cannot be empty")
+
+    search_versions = resolve_search_versions(version, runtime_version, all_versions)
+
+    cache_key = f"search:{query}:{','.join(search_versions)}:{include_external}:{limit}"
+    with _cache_lock:
+        if cache_key in _search_result_cache:
+            return _search_result_cache[cache_key]
+
+    hits: List[tuple] = []
+    for candidate in search_versions:
+        index = get_index(
+            docs_path, f"version:{candidate}",
+            lambda c=candidate: load_version_sections(docs_path, c),
+        )
+        found = index.search(query, limit) or index.substring_search(query, limit)
+        hits.extend(found)
+
+    if include_external and external_dir and Path(external_dir).is_dir():
+        for service_dir in sorted(Path(external_dir).iterdir()):
+            if not service_dir.is_dir():
+                continue
+            index = get_index(
+                docs_path, f"service:{service_dir.name}",
+                lambda s=service_dir.name: load_service_sections(external_dir, s),
+            )
+            found = index.search(query, limit) or index.substring_search(query, limit)
+            hits.extend(found)
+
+    hits.sort(key=lambda pair: pair[1], reverse=True)
+    hits = hits[:limit]
+
+    if not hits:
+        result = format_error(
+            f"No results found for '{query}'",
+            {"scope": ", ".join(search_versions)},
+        )
+    else:
+        result = toon_encode({
+            "query": query,
+            "scope": ", ".join(search_versions),
+            "results": [
+                {
+                    "file": f"{section.version}/{section.filename}",
+                    "anchor": section.anchor or "",
+                    "heading": section.heading,
+                    "score": round(score, 2),
+                    "snippet": extract_snippet(section.text, query),
+                }
+                for section, score in hits
+            ],
+        })
+
+    with _cache_lock:
+        _search_result_cache[cache_key] = result
+        if len(_search_result_cache) > _SEARCH_CACHE_MAX_ENTRIES:
+            for key in list(_search_result_cache.keys())[:_SEARCH_CACHE_EVICT_COUNT]:
+                del _search_result_cache[key]
+
+    return result
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_retrieval_quality.py -q --no-cov`
+Expected: PASS, 10 tests
+
+- [ ] **Step 5: Run the whole suite and fix fallout**
+
+Run: `.venv/bin/python -m pytest -q --no-cov`
+
+Existing tests assert the old output shape. Update the assertions to the new
+shape rather than weakening them; if a test mocked `os.listdir` or
+`get_file_content_cached` to control search input, give it real files instead —
+enumeration now goes through `list_contained_markdown`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_tools.py tests/
+git lc -m "Rank documentation search by BM25 over sections"
+```
+
+---
+
+### Task 8: read_laravel_doc_section
+
+**Files:**
+- Modify: `mcp_tools.py`
+- Test: `tests/unit/test_retrieval_quality.py`
+
+**Interfaces:**
+- Consumes: `chunk_markdown` (Task 1); existing `validate_version`, `resolve_contained_path`, `get_file_content_cached`.
+- Produces: `read_laravel_doc_section_impl(docs_path, filename, section, version=None, runtime_version=None) -> str`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/unit/test_retrieval_quality.py
+def test_read_section_by_anchor(tmp_path):
+    from mcp_tools import read_laravel_doc_section_impl
+
+    docs = tmp_path / "docs"
+    (docs / VERSION).mkdir(parents=True)
+    (docs / VERSION / "queues.md").write_text(
+        '# Queues\n\n<a name="failed-jobs"></a>\n## Failed Jobs\n\n'
+        "Retry with queue:retry.\n\n## Other\n\nUnrelated.\n"
+    )
+
+    result = read_laravel_doc_section_impl(docs, "queues.md", "failed-jobs", VERSION)
+
+    assert "queue:retry" in result
+    assert "Unrelated" not in result
+
+
+def test_read_section_by_heading_case_insensitively(tmp_path):
+    from mcp_tools import read_laravel_doc_section_impl
+
+    docs = tmp_path / "docs"
+    (docs / VERSION).mkdir(parents=True)
+    (docs / VERSION / "queues.md").write_text("## Failed Jobs\n\nRetry it.\n")
+
+    result = read_laravel_doc_section_impl(docs, "queues.md", "failed jobs", VERSION)
+
+    assert "Retry it." in result
+
+
+def test_unknown_section_lists_available_ones(tmp_path):
+    from mcp_tools import read_laravel_doc_section_impl
+
+    docs = tmp_path / "docs"
+    (docs / VERSION).mkdir(parents=True)
+    (docs / VERSION / "queues.md").write_text(
+        '<a name="failed-jobs"></a>\n## Failed Jobs\n\nBody.\n'
+    )
+
+    result = read_laravel_doc_section_impl(docs, "queues.md", "nope", VERSION)
+
+    assert "failed-jobs" in result
+
+
+def test_read_section_rejects_traversal(tmp_path):
+    from mcp_tools import read_laravel_doc_section_impl
+
+    docs = tmp_path / "docs"
+    (docs / VERSION).mkdir(parents=True)
+    (tmp_path / "secret.md").write_text("## Secret\n\nCANARY-5150\n")
+
+    result = read_laravel_doc_section_impl(docs, "../../secret.md", "secret", VERSION)
+
+    assert "CANARY-5150" not in result
+
+
+def test_read_section_rejects_invalid_version(tmp_path):
+    from mcp_tools import read_laravel_doc_section_impl
+
+    result = read_laravel_doc_section_impl(tmp_path, "queues.md", "failed-jobs", "..")
+
+    assert "Invalid version" in result
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_retrieval_quality.py -q --no-cov -k read_section`
+Expected: FAIL with `ImportError: cannot import name 'read_laravel_doc_section_impl'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# add to mcp_tools.py
+def read_laravel_doc_section_impl(
+    docs_path: Path,
+    filename: str,
+    section: str,
+    version: Optional[str] = None,
+    runtime_version: Optional[str] = None,
+) -> str:
+    """Return one ## section of a documentation file.
+
+    `section` matches either the anchor or the heading text, case-insensitively,
+    because search output shows both and the caller should not have to guess
+    which is canonical.
+    """
+    version_error = validate_version(version)
+    if version_error:
+        return version_error
+
+    if not version:
+        version = runtime_version if runtime_version else DEFAULT_VERSION
+
+    if not filename.endswith('.md'):
+        filename = f"{filename}.md"
+
+    version_path = Path(docs_path) / version
+    safe_path = resolve_contained_path(version_path, version_path / filename)
+    if safe_path is None:
+        logger.warning(f"Access denied: {filename} (attempted directory traversal)")
+        return f"Access denied: {filename} (attempted directory traversal)"
+
+    if not safe_path.exists():
+        return f"Documentation file not found: {filename} (version: {version})"
+
+    content = get_file_content_cached(str(safe_path))
+    if content.startswith("Error") or content.startswith("File not found"):
+        return content
+
+    wanted = section.strip().lower().lstrip('#')
+    sections = chunk_markdown(content, filename, version)
+
+    for candidate in sections:
+        if (candidate.anchor or "").lower() == wanted or candidate.heading.lower() == wanted:
+            return candidate.text.strip()
+
+    available = [s.anchor or s.heading for s in sections]
+    return format_error(
+        f"Section '{section}' not found in {filename}",
+        {"available_sections": available},
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_retrieval_quality.py -q --no-cov`
+Expected: PASS, 15 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp_tools.py tests/unit/test_retrieval_quality.py
+git lc -m "Add section-level documentation reads"
+```
+
+---
+
+### Task 9: Tool layer — expose the section reader, retire with_context
+
+**Files:**
+- Modify: `laravel_mcp_companion.py`
+- Modify: `mcp_tools.py` (delete `search_laravel_docs_with_context_impl`)
+- Test: `tests/unit/test_retrieval_quality.py`
+
+**Interfaces:**
+- Consumes: `read_laravel_doc_section_impl` (Task 8), `search_laravel_docs_impl` (Task 7).
+- Produces: MCP tools `search_laravel_docs` (new output shape) and `read_laravel_doc_section`; `search_laravel_docs_with_context` no longer registered.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/unit/test_retrieval_quality.py
+@pytest.mark.asyncio
+async def test_section_reader_is_exposed_as_a_tool(tmp_path):
+    from fastmcp import Client
+
+    from laravel_mcp_companion import create_mcp_server
+
+    docs = tmp_path / "docs"
+    (docs / VERSION).mkdir(parents=True)
+    (docs / VERSION / "queues.md").write_text(
+        '<a name="failed-jobs"></a>\n## Failed Jobs\n\nRetry with queue:retry.\n'
+    )
+
+    server = create_mcp_server("T", docs, VERSION, transform_mode=None)
+    async with Client(server) as client:
+        names = [t.name for t in await client.list_tools()]
+        assert "read_laravel_doc_section" in names
+        assert "search_laravel_docs_with_context" not in names
+
+        result = await client.call_tool(
+            "read_laravel_doc_section",
+            {"filename": "queues.md", "section": "failed-jobs", "version": VERSION},
+        )
+        assert "queue:retry" in result.content[0].text
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_retrieval_quality.py -q --no-cov -k exposed`
+Expected: FAIL, `assert 'read_laravel_doc_section' in [...]`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `laravel_mcp_companion.py`, remove the `search_laravel_docs_with_context` tool
+definition and its import, then register the new tool alongside
+`read_laravel_doc_content`:
+
+```python
+    @mcp.tool(
+        description=(
+            "Read one section of a Laravel documentation file by its anchor or "
+            "heading, as returned by search_laravel_docs. Prefer this over "
+            "read_laravel_doc_content: a whole file can exceed 30,000 tokens."
+        ),
+        annotations={"readOnlyHint": True, "idempotentHint": True},
+        tags={"docs", "read"}
+    )
+    def read_laravel_doc_section(filename: str, section: str, version: Optional[str] = None) -> str:
+        """Read a single documentation section.
+
+        Args:
+            filename: Documentation file, e.g. 'queues.md'
+            section: Anchor or heading, e.g. 'dealing-with-failed-jobs'
+            version: Laravel version. Defaults to the configured version.
+        """
+        return read_laravel_doc_section_impl(
+            docs_path, filename, section, version, runtime_version=runtime_version
+        )
+```
+
+Update the import block to add `read_laravel_doc_section_impl` and drop
+`search_laravel_docs_with_context_impl`, then delete
+`search_laravel_docs_with_context_impl` from `mcp_tools.py`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_retrieval_quality.py -q --no-cov`
+Expected: PASS, 16 tests
+
+- [ ] **Step 5: Run the whole suite, ruff and mypy**
+
+```bash
+.venv/bin/python -m pytest -q --no-cov
+.venv/bin/ruff check .
+.venv/bin/mypy --ignore-missing-imports .
+```
+
+Remove any test that exercised `search_laravel_docs_with_context`; its coverage is
+replaced by the retrieval-quality tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add laravel_mcp_companion.py mcp_tools.py tests/
+git lc -m "Expose section reads and retire the substring context search"
+```
+
+---
+
+### Task 10: Documentation and changelog
+
+**Files:**
+- Modify: `README.md`
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: no code.
+
+- [ ] **Step 1: Update the CHANGELOG**
+
+Add under `## [Unreleased]`:
+
+```markdown
+### Breaking
+- `search_laravel_docs` returns ranked sections with snippets rather than files
+  with match counts, and `search_laravel_docs_with_context` is removed. Both
+  matched the query as a literal substring, so four of seven realistic developer
+  questions returned nothing; ranking by match count also placed `queues.md`
+  13th of 24 for "queues".
+
+### Added
+- `read_laravel_doc_section` reads one section by anchor or heading. Answering a
+  typical question drops from ~34,000 tokens to under 3,000.
+```
+
+- [ ] **Step 2: Update the README**
+
+In the tools section, document `read_laravel_doc_section` and note that
+`search_laravel_docs` now returns sections with anchors. Remove any mention of
+`search_laravel_docs_with_context`.
+
+- [ ] **Step 3: Verify the version-consistency guard still passes**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_version_consistency.py -q --no-cov`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md CHANGELOG.md
+git lc -m "Document section reads and the new search output"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** Chunking at `##` — Task 1. Owned BM25 — Task 2. Snippets — Task 3. Lazy per-version registry with LRU cap of 2 — Task 4. Invalidation through `clear_caches` — Task 5. External service docs keyed by service — Task 6 (`load_service_sections`) and Task 7 (the service loop). Merged ranking across corpora — Task 7 (`hits.sort` then truncate). Substring fallback — Task 4 (`substring_search`), used in Task 7. Tool contract change and `with_context` removal — Task 9. Token budget — Task 7's budget test. Traversal and containment reuse — Tasks 6 and 8.
+
+**Placeholders.** None: every code step carries real code, and every test step carries real assertions.
+
+**Type consistency.** `Section` fields are used identically in Tasks 1, 6, 7 and 8. `BM25Index.query` returns `list[tuple[int, float]]` in Task 2 and is consumed as `(i, score)` in Task 4. `DocIndex.search` returns `list[tuple[Section, float]]` in Task 4 and is consumed as `(section, score)` in Task 7. `get_index(docs_path, key, loader)` is defined in Task 4 and called with that signature in Task 7. `chunk_markdown(text, filename, version)` is defined in Task 1 and called with that signature in Tasks 6 and 8.
+
+**One gap found and closed:** the spec says results are labelled with the service for external hits. Task 7 renders `f"{section.version}/{section.filename}"`, and Task 6 sets `version=service` for service sections, so a Forge hit renders as `forge/introduction.md`. No extra field is needed.

--- a/docs/superpowers/specs/2026-07-31-chunked-bm25-retrieval-design.md
+++ b/docs/superpowers/specs/2026-07-31-chunked-bm25-retrieval-design.md
@@ -1,0 +1,224 @@
+# Chunked BM25 Retrieval — Design
+
+**Date:** 2026-07-31
+**Status:** Approved, not yet implemented
+
+## Problem
+
+The project's purpose is to make it as easy as possible to have the latest Laravel
+documentation at the ready when using LLMs. Acquisition works: all eight versions
+match `laravel/docs` branch HEAD exactly. Retrieval does not.
+
+`search_laravel_docs` compiles the query with `re.escape` and ranks by raw match
+count. Measured against `docs/13.x`:
+
+| query | result today |
+|---|---|
+| `how do I validate a file upload` | 0 results |
+| `retry failed queue job` | 0 results |
+| `send email with attachment` | 0 results |
+| `rate limiting api routes` | 0 results |
+| `database transactions` | ok |
+| `eloquent relationships` | ok |
+| `queue` | ok |
+
+**Four of seven realistic questions return nothing**, because a multi-word question
+is rarely a verbatim substring. Ranking is also anti-correlated with relevance: raw
+term frequency rewards long files, so `queues.md` (54 matches) ranks 13th of 24 for
+"queues", behind `images.md` (1 match). There is no IDF and no length normalization.
+
+When search fails the only fallback is `read_laravel_doc_content`, which returns
+whole files. `queues.md` is ~34,048 tokens; 25% of 13.x files exceed 10,000. The
+sections that answer a typical question are roughly 28% of that.
+
+The root cause is structural: **there is no retrieval unit between a filename and a
+whole file.**
+
+## Goals
+
+1. Multi-word natural-language questions return relevant results.
+2. Results are ranked by relevance, not by file length.
+3. Answering a typical question costs hundreds of tokens, not tens of thousands.
+4. Results cite a section that can be fetched directly.
+
+## Non-goals
+
+Stemming, synonym expansion, embeddings or semantic search, a persisted index,
+and cross-encoder reranking. Also out of scope, each its own change: the freshness
+metric reporting fetch-age instead of content-age, `read_laravel_doc_content` not
+being pinned in the search transform, and the unused `TOOL_DESCRIPTIONS` entries.
+
+## Architecture
+
+A new module, `doc_search.py`. `mcp_tools.py` is already ~1,300 lines of tool
+implementations; chunking, indexing and scoring are a separate concern with a clean
+interface and are far easier to test standalone.
+
+```
+Section            dataclass: version, filename, anchor, heading, text
+chunk_markdown()   split on ## ; capture <a name="..."> anchor for citation
+BM25Index          build(docs) / query(text, k) -> [(index, score)]
+DocIndex           per-version lazy index, snippet extraction, LRU registry
+```
+
+`BM25Index` is roughly 40 lines of Okapi BM25 (k1=1.5, b=0.75), owned rather than
+imported. fastmcp ships `_BM25Index`, which is generic enough to reuse, but it is a
+private underscore-prefixed class in a fast-moving dependency, and it retains its
+token lists after `build()` — most of the measured 26.5 MB per version. Owning it
+drops those and roughly halves the footprint. This project was broken twice in one
+week by upstream changes it did not control (MCP Inspector 2.0's CLI, ruff 0.15's
+default rule set); a private class is the same bet a third time.
+
+### Chunk granularity
+
+Chunk on `##`. Measured on `docs/13.x`:
+
+| granularity | chunks | avg tokens | correct top-1 of 4 |
+|---|---|---|---|
+| `##` | 838 | ~1,013 | **4** |
+| `##` + `###` | 2,167 | ~391 | 2 |
+| `<a name>` anchors | 4,117 | ~206 | 2 |
+
+Finer chunks are sharper when they hit — `### Retrying Failed Jobs` beats
+`## Dealing With Failed Jobs` — but regress elsewhere. "validate a file upload"
+drifts to `filesystem.md#temporary-upload-urls`, and "rate limiting api routes"
+collapses onto the file-header chunk, because short chunks give BM25 too few terms
+to discriminate. Anchors are better as citation and drill-down targets than as
+index units.
+
+### Index lifecycle
+
+A module-level `{version: DocIndex}` registry, built on first query for a version
+and cleared by the existing `clear_caches()`, which already runs on documentation
+update — invalidation needs no new machinery.
+
+Measured: 6 ms to chunk, 103 ms to build, 0.4 ms per query for one version (838
+sections). Precomputing an index at sync time and shipping it was considered and
+rejected: it adds a build step, image weight, and a staleness failure mode to save
+a tenth of a second.
+
+Memory is the binding constraint at ~13 MB per version after dropping token lists.
+**At most two indexes stay resident, LRU-evicted.** Search already defaults to a
+single version, so `all_versions=true` is the rare path; it sweeps versions and
+rebuilds at ~100 ms each, trading speed on an uncommon call for a bounded footprint.
+
+### External service documentation
+
+`include_external=True` is the existing default and must keep working.
+`docs/external/<service>/*.md` is markdown with the same heading structure, so it
+is chunked and indexed identically, keyed by service name rather than version, in
+the same registry and under the same LRU cap. A `Section` from external docs
+carries the service in place of the version, and results label it as such.
+
+### Ranking across multiple corpora
+
+When more than one version or service is searched, each is queried against its own
+index and the hits are merged by score, then truncated to `limit`.
+
+BM25 scores from separate corpora are not formally comparable, since IDF is
+computed per index. In practice these corpora are near-identical in size,
+vocabulary and structure — they are the same documentation at different versions —
+so the scores are close enough to rank against each other. This is an
+approximation, and it is the reason the default remains a single version rather
+than a merged sweep.
+
+## Tool contract
+
+Breaking, by decision. `search_laravel_docs` keeps its name and gains a new output
+shape; leaving the broken implementation as the default would undercut the fix.
+`search_laravel_docs_with_context` is removed as redundant — it is substring-based
+and returns nothing for the same queries.
+
+```
+search_laravel_docs(query, version=None, include_external=True,
+                    all_versions=False, limit=5)
+```
+
+```
+query: retry failed queue job
+scope: 13.x
+results[3]{file,anchor,heading,score,snippet}:
+  queues.md,dealing-with-failed-jobs,Dealing With Failed Jobs,8.4,
+    "...jobs exceeding max attempts are inserted into the
+     failed_jobs table. Retry with php artisan queue:retry..."
+```
+
+Snippets are a ~300-character window on line boundaries around the highest-scoring
+term, so they read as prose rather than a mid-word slice.
+
+```
+read_laravel_doc_section(filename, section, version=None)
+```
+
+`section` accepts either the anchor (`dealing-with-failed-jobs`) or the heading
+text, case-insensitively. The model sees both in search output and should not have
+to guess which is canonical. An unknown section returns the available anchors,
+making the error a discovery path rather than a dead end.
+
+### Substring fallback
+
+If BM25 returns no results, fall back to literal substring matching over the same
+sections. This preserves the one thing the current implementation does well —
+exact symbol lookup such as `mimes:pdf` or `Rule::contains` — for about five lines.
+Without it this change would be a straight upgrade that quietly loses a capability.
+
+## Data flow
+
+```
+search_laravel_docs(query, ...)
+  -> validate_version / resolve_search_versions       (existing)
+  -> get_or_build_index(version)                      (lazy, LRU)
+  -> BM25 query -> top-k (Section, score)
+  -> substring fallback if empty
+  -> extract_snippet per hit
+  -> TOON encode
+
+read_laravel_doc_section(filename, section, version)
+  -> validate_version                                 (existing)
+  -> resolve_contained_path                           (existing)
+  -> chunk file, match anchor or heading
+  -> return section text, or available anchors
+```
+
+Chunking reads through `list_contained_markdown`, and section reads validate via
+`validate_version` and `resolve_contained_path`, so the containment and TOCTOU
+hardening carries over unchanged rather than being reimplemented.
+
+## Error handling
+
+Empty query and invalid version reuse the existing validators. No results reports
+the versions actually searched. Unreadable directories propagate rather than
+reporting "no files found", matching the decision already made in
+`list_contained_markdown`. An unknown section lists the available anchors.
+
+## Testing
+
+Written failing-first, per the test-driven-development skill.
+
+- `chunk_markdown`: anchor and heading capture; a file with no `##`; preamble
+  before the first heading; a heading with no anchor
+- `BM25Index`: known-answer scoring; empty corpus; a query whose terms appear
+  nowhere; verification that token lists are released after `build()`
+- **Retrieval regression:** the seven realistic queries above, currently 3/7, must
+  reach 7/7. Asserted as a test rather than claimed in a commit message.
+- **Ranking:** `queues.md` outranks `images.md` for "queues" (13th of 24 today)
+- **Token budget:** a `limit=5` search response stays under 1,200 tokens
+  (~4,800 characters), so output cannot silently balloon back toward whole-file
+  cost. Measured against today's 34,048-token path for the same question.
+- Substring fallback returns results for an exact symbol that BM25 misses
+- `read_laravel_doc_section`: by anchor; by heading; case-insensitive; unknown
+  section lists anchors; traversal still blocked
+- LRU eviction holds at two resident indexes
+- End-to-end through a real `fastmcp.Client`
+
+## Risks
+
+**A fifth breaking change since v0.10.0.** Mitigated by keeping the tool name and
+arguments stable — only the result shape changes — and by the fact that the tool
+being replaced returns nothing for most real queries.
+
+**BM25 quality is not guaranteed to generalize** beyond the queries measured here.
+The regression test pins seven; more should be added as real failures surface.
+
+**Snippets may cut mid-sentence** despite line-boundary alignment. Acceptable: the
+anchor is always returned, so full text is one call away.

--- a/laravel_mcp_companion.py
+++ b/laravel_mcp_companion.py
@@ -771,6 +771,17 @@ def parse_arguments():
     if args.allowed_host is None:
         args.allowed_host = _split_env_list("ALLOWED_HOSTS") or []
 
+    # Allowed hosts are matched with fnmatch, so a pattern entry would match
+    # every Host header and silently disable the guard while still looking like
+    # a configured allowlist. Reject them the way wildcard CORS origins are.
+    wildcard_hosts = [h for h in args.allowed_host if any(c in h for c in "*?[")]
+    if wildcard_hosts:
+        parser.error(
+            f"wildcard patterns are not accepted in allowed hosts: {', '.join(wildcard_hosts)}. "
+            "List each hostname explicitly; a pattern would match every Host header "
+            "and disable DNS-rebinding protection."
+        )
+
     return args
 
 def setup_docs_path(user_path: Optional[str] = None) -> Path:

--- a/laravel_mcp_companion.py
+++ b/laravel_mcp_companion.py
@@ -35,7 +35,7 @@ from mcp_tools import (
     list_laravel_docs_impl,
     read_laravel_doc_content_impl,
     search_laravel_docs_impl,
-    search_laravel_docs_with_context_impl,
+    read_laravel_doc_section_impl,
     get_doc_structure_impl,
     browse_docs_by_category_impl,
     verify_laravel_feature_impl,
@@ -1773,32 +1773,26 @@ def configure_mcp_server(mcp: FastMCP, docs_path: Path, runtime_version: str, mu
         return read_laravel_doc_content_impl(docs_path, filename, version, runtime_version=runtime_version)
 
     @mcp.tool(
-        description="Search Laravel docs with context snippets",
+        description=(
+            "Read one section of a Laravel documentation file by the anchor or "
+            "heading returned by search_laravel_docs. Prefer this over "
+            "read_laravel_doc_content: a whole file can exceed 30,000 tokens, "
+            "while a section is typically a few hundred."
+        ),
         annotations={"readOnlyHint": True, "idempotentHint": True},
         tags={"docs", "read"}
     )
-    def search_laravel_docs_with_context(
-        query: str,
-        version: Optional[str] = None,
-        context_length: int = 200,
-        include_external: bool = True,
-        all_versions: bool = False
-    ) -> str:
-        """
-        Search through Laravel documentation with context snippets.
+    def read_laravel_doc_section(filename: str, section: str, version: Optional[str] = None) -> str:
+        """Read a single documentation section.
 
         Args:
-            query: Search term
-            version: Specific version, or None for the configured version
-            context_length: Characters of context to show (default: 200)
-            include_external: Whether to include external Laravel services documentation
-            all_versions: Search every supported version instead of just the configured one
-
-        Returns:
-            Search results with context snippets
+            filename: Documentation file, e.g. 'queues.md'
+            section: Anchor or heading, e.g. 'dealing-with-failed-jobs'
+            version: Laravel version. Defaults to the configured version.
         """
-        external_dir = multi_updater.external_fetcher.external_dir if include_external else None
-        return search_laravel_docs_with_context_impl(docs_path, query, version, context_length, include_external, external_dir, runtime_version=runtime_version, all_versions=all_versions)
+        return read_laravel_doc_section_impl(
+            docs_path, filename, section, version, runtime_version=runtime_version
+        )
 
     @mcp.tool(
         description="Get the structure and sections of a documentation file",

--- a/laravel_mcp_companion.py
+++ b/laravel_mcp_companion.py
@@ -48,7 +48,7 @@ from mcp_tools import (
     search_laravel_learning_resources_impl,
     list_laravel_learning_resources_impl,
     list_laravel_categories_impl,
-    is_safe_path,
+    resolve_contained_path,
     validate_version as validate_version_arg,
     count_matches,
     clear_caches as clear_mcp_tools_caches,
@@ -1359,23 +1359,25 @@ def create_mcp_server(server_name: str, docs_path: Path, runtime_version: str, t
         
         file_path = Path(config['docs_path']) / version_inner / relative_path
         
-        # Security check - ensure we stay within version directory
+        # Security check - read the resolved path this returns, not file_path,
+        # so the file that was checked is the file that gets opened.
         version_path = Path(config['docs_path']) / version_inner
-        if not is_safe_path(version_path, file_path):
+        safe_path = resolve_contained_path(version_path, file_path)
+        if safe_path is None:
             logger.warning(f"Access denied: {path} (attempted directory traversal)")
             return f"Access denied: {path} (attempted directory traversal)"
-        
-        if not file_path.exists():
-            logger.warning(f"Documentation file not found: {file_path}")
+
+        if not safe_path.exists():
+            logger.warning(f"Documentation file not found: {safe_path}")
             return f"Documentation file not found: {path} (version: {version_inner})"
-        
+
         try:
-            content = get_file_content_cached(str(file_path))
+            content = get_file_content_cached(str(safe_path))
             if not content.startswith("Error") and not content.startswith("File not found"):
-                logger.debug(f"Successfully read file: {file_path} ({len(content)} bytes)")
+                logger.debug(f"Successfully read file: {safe_path} ({len(content)} bytes)")
             return content
         except Exception as e:
-            logger.error(f"Error reading file {file_path}: {str(e)}")
+            logger.error(f"Error reading file {safe_path}: {str(e)}")
             return f"Error reading file: {str(e)}"
     
     def read_external_laravel_doc(service: str, path: str) -> str:
@@ -1397,11 +1399,13 @@ def create_mcp_server(server_name: str, docs_path: Path, runtime_version: str, t
             
             file_path = service_dir / path
             
-            # Security check - ensure we stay within service directory
-            if not is_safe_path(service_dir, file_path):
+            # Security check - open the resolved path this returns, not
+            # file_path, so the check and the open see the same file.
+            safe_path = resolve_contained_path(service_dir, file_path)
+            if safe_path is None:
                 return f"Access denied: {service}/{path} (path traversal attempted)"
-            
-            if not file_path.exists():
+
+            if not safe_path.exists():
                 # List available files to help user
                 available_files = []
                 try:
@@ -1414,9 +1418,9 @@ def create_mcp_server(server_name: str, docs_path: Path, runtime_version: str, t
                 else:
                     return f"File not found: {service}/{path}. No documentation cached for {service}. Use update_external_laravel_docs(['{service}']) to fetch documentation."
             
-            with open(file_path, 'r', encoding='utf-8') as f:
+            with open(safe_path, 'r', encoding='utf-8') as f:
                 content = f.read()
-                logger.debug(f"Successfully read external file: {file_path} ({len(content)} bytes)")
+                logger.debug(f"Successfully read external file: {safe_path} ({len(content)} bytes)")
                 return content
         except Exception as e:
             logger.error(f"Error reading external file {service}/{path}: {str(e)}")

--- a/mcp_tools.py
+++ b/mcp_tools.py
@@ -535,21 +535,24 @@ def read_laravel_doc_content_impl(docs_path: Path, filename: str, version: Optio
         return f"Error reading file: {str(e)}"
 
 
-def search_laravel_docs_impl(docs_path: Path, query: str, version: Optional[str] = None, include_external: bool = True, external_dir: Optional[Path] = None, runtime_version: Optional[str] = None, all_versions: bool = False) -> str:
-    """Search through Laravel documentation for a specific term.
+def search_laravel_docs_impl(
+    docs_path: Path,
+    query: str,
+    version: Optional[str] = None,
+    include_external: bool = True,
+    external_dir: Optional[Path] = None,
+    runtime_version: Optional[str] = None,
+    all_versions: bool = False,
+    limit: int = 5,
+) -> str:
+    """Search documentation, returning ranked sections with snippets.
 
-    Args:
-        docs_path: Base path for documentation
-        query: Search term to look for
-        version: Specific Laravel version to search (e.g., "12.x"). Defaults to the configured version.
-        include_external: Whether to include external Laravel services documentation in search
-        external_dir: Path to external documentation directory
-        all_versions: Search every supported version instead of just the configured one
-
-    Returns:
-        TOON-encoded structured search results.
+    Ranked by BM25 over ## sections rather than by literal substring count, so a
+    multi-word question matches at all and long files no longer outrank relevant
+    ones. Each hit carries an anchor so the full section can be fetched with
+    read_laravel_doc_section instead of reading the whole file.
     """
-    logger.debug(f"search_laravel_docs_impl called with query: {query}, version: {version}, include_external: {include_external}")
+    from doc_search import extract_snippet, get_index
 
     version_error = validate_version(version)
     if version_error:
@@ -560,80 +563,70 @@ def search_laravel_docs_impl(docs_path: Path, query: str, version: Optional[str]
 
     search_versions = resolve_search_versions(version, runtime_version, all_versions)
 
-    # Check cache for search results
-    cache_key = f"search:{query}:{','.join(search_versions)}:{include_external}"
+    cache_key = f"search:{query}:{','.join(search_versions)}:{include_external}:{limit}"
     with _cache_lock:
         if cache_key in _search_result_cache:
             logger.debug(f"Returning cached search results for: {query}")
             return _search_result_cache[cache_key]
 
-    core_results_data: List[Dict] = []
-    external_results_data: List[Dict] = []
-    pattern = re.compile(re.escape(query), re.IGNORECASE)
+    hits: List[tuple] = []
 
-    try:
-        # Search core Laravel documentation
-        for v in search_versions:
-            version_path = docs_path / v
-            if not version_path.exists():
+    for candidate in search_versions:
+        index = get_index(
+            docs_path,
+            f"version:{candidate}",
+            lambda c=candidate: load_version_sections(docs_path, c),
+        )
+        # Literal fallback preserves exact-symbol lookup such as `queue:retry`,
+        # which tokenized scoring splits apart.
+        hits.extend(index.search(query, limit) or index.substring_search(query, limit))
+
+    if include_external and external_dir and Path(external_dir).is_dir():
+        for service_dir in sorted(Path(external_dir).iterdir()):
+            if not service_dir.is_dir():
                 continue
-
-            for file, file_path in list_contained_markdown(version_path):
-                content = get_file_content_cached(str(file_path))
-                if not content.startswith("Error") and not content.startswith("File not found"):
-                    count = count_matches(pattern, content)
-                    if count:
-                        core_results_data.append({
-                            "file": f"{v}/{file}",
-                            "matches": count
-                        })
-
-        # Search external documentation if requested
-        if include_external and external_dir and external_dir.exists():
-            for service_dir in external_dir.iterdir():
-                if service_dir.is_dir():
-                    service_name = service_dir.name
-
-                    for file_path in service_dir.glob("*.md"):
-                        try:
-                            content = get_file_content_cached(str(file_path))
-                            if not content.startswith("Error") and not content.startswith("File not found"):
-                                count = count_matches(pattern, content)
-                                if count:
-                                    external_results_data.append({
-                                        "service": service_name,
-                                        "file": file_path.name,
-                                        "matches": count
-                                    })
-                        except Exception as e:
-                            logger.warning(f"Error searching {file_path}: {str(e)}")
-                            continue
-
-        # Format combined results
-        if not core_results_data and not external_results_data:
-            search_scope = f"version {version}" if version else f"versions {', '.join(search_versions)}"
-            result = format_error(f"No results found for '{query}'", {"scope": search_scope})
-        else:
-            result = format_search_results(
-                query,
-                core_results_data,
-                external_results_data if external_results_data else None
+            service = service_dir.name
+            index = get_index(
+                docs_path,
+                f"service:{service}",
+                lambda s=service: load_service_sections(external_dir, s),
             )
+            hits.extend(index.search(query, limit) or index.substring_search(query, limit))
 
-        # Cache the search result
-        with _cache_lock:
-            _search_result_cache[cache_key] = result
-            # Limit cache size
-            if len(_search_result_cache) > _SEARCH_CACHE_MAX_ENTRIES:
-                # Remove oldest entries
-                oldest_keys = list(_search_result_cache.keys())[:_SEARCH_CACHE_EVICT_COUNT]
-                for key in oldest_keys:
-                    del _search_result_cache[key]
+    # Scores from separate indexes are only approximately comparable, since IDF
+    # is per-corpus. These corpora are the same documentation at different
+    # versions, so they are close enough to rank against each other.
+    hits.sort(key=lambda pair: pair[1], reverse=True)
+    hits = hits[:limit]
 
-        return result
-    except Exception as e:
-        logger.error(f"Error searching documentation: {str(e)}")
-        return format_error(f"Error searching documentation: {str(e)}")
+    if not hits:
+        result = format_error(
+            f"No results found for '{query}'",
+            {"scope": ", ".join(search_versions)},
+        )
+    else:
+        result = toon_encode({
+            "query": query,
+            "scope": ", ".join(search_versions),
+            "results": [
+                {
+                    "file": f"{section.version}/{section.filename}",
+                    "anchor": section.anchor or "",
+                    "heading": section.heading,
+                    "score": round(score, 2),
+                    "snippet": extract_snippet(section.text, query),
+                }
+                for section, score in hits
+            ],
+        })
+
+    with _cache_lock:
+        _search_result_cache[cache_key] = result
+        if len(_search_result_cache) > _SEARCH_CACHE_MAX_ENTRIES:
+            for key in list(_search_result_cache.keys())[:_SEARCH_CACHE_EVICT_COUNT]:
+                del _search_result_cache[key]
+
+    return result
 
 
 def search_laravel_docs_with_context_impl(docs_path: Path, query: str, version: Optional[str] = None,

--- a/mcp_tools.py
+++ b/mcp_tools.py
@@ -1350,8 +1350,15 @@ def list_laravel_categories_impl() -> str:
 
 
 def clear_caches():
-    """Clear all caches."""
+    """Clear all caches, including the documentation search indexes.
+
+    Imported locally: doc_search does not import mcp_tools, but mcp_tools
+    imports doc_search, and a module-level import here would be circular.
+    """
+    from doc_search import clear_indexes
+
     with _cache_lock:
         _file_content_cache.clear()
         _search_result_cache.clear()
+    clear_indexes()
     logger.info("Caches cleared")

--- a/mcp_tools.py
+++ b/mcp_tools.py
@@ -20,7 +20,6 @@ from docs_updater import get_cached_supported_versions, DEFAULT_VERSION
 from toon_helpers import (
     toon_encode,
     format_version_list,
-    format_search_results,
     format_category_docs,
     format_doc_structure,
     format_error,
@@ -625,11 +624,10 @@ def search_laravel_docs_impl(
     hits: List[tuple] = []
 
     for candidate in search_versions:
-        index = get_index(
-            docs_path,
-            f"version:{candidate}",
-            lambda c=candidate: load_version_sections(docs_path, c),
-        )
+        def load_version(c: str = candidate) -> List[Section]:
+            return load_version_sections(docs_path, c)
+
+        index = get_index(docs_path, f"version:{candidate}", load_version)
         # Literal fallback preserves exact-symbol lookup such as `queue:retry`,
         # which tokenized scoring splits apart.
         hits.extend(index.search(query, limit) or index.substring_search(query, limit))
@@ -639,11 +637,10 @@ def search_laravel_docs_impl(
             if not service_dir.is_dir():
                 continue
             service = service_dir.name
-            index = get_index(
-                docs_path,
-                f"service:{service}",
-                lambda s=service: load_service_sections(external_dir, s),
-            )
+            def load_service(name: str = service) -> List[Section]:
+                return load_service_sections(external_dir, name)
+
+            index = get_index(docs_path, f"service:{service}", load_service)
             hits.extend(index.search(query, limit) or index.substring_search(query, limit))
 
     # Scores from separate indexes are only approximately comparable, since IDF
@@ -680,111 +677,6 @@ def search_laravel_docs_impl(
                 del _search_result_cache[key]
 
     return result
-
-
-def search_laravel_docs_with_context_impl(docs_path: Path, query: str, version: Optional[str] = None,
-                                         context_length: int = 200, include_external: bool = True,
-                                         external_dir: Optional[Path] = None, runtime_version: Optional[str] = None,
-                                         all_versions: bool = False) -> str:
-    """Search Laravel documentation and return matches with surrounding context.
-
-    Args:
-        docs_path: Base path for documentation
-        query: Search term to look for
-        version: Specific Laravel version to search. Defaults to the configured version.
-        context_length: Number of characters to show before/after match
-        include_external: Whether to include external Laravel services documentation
-        external_dir: Path to external documentation directory
-        all_versions: Search every supported version instead of just the configured one
-    """
-    logger.debug(f"search_laravel_docs_with_context_impl called with query: {query}")
-
-    version_error = validate_version(version)
-    if version_error:
-        return version_error
-
-    if not query.strip():
-        return "Search query cannot be empty"
-
-    results = []
-    pattern = re.compile(re.escape(query), re.IGNORECASE)
-
-    try:
-        # Search core documentation
-        search_versions = resolve_search_versions(version, runtime_version, all_versions)
-
-        for v in search_versions:
-            version_path = docs_path / v
-            if not version_path.exists():
-                continue
-            
-            for file, file_path in list_contained_markdown(version_path):
-                content = get_file_content_cached(str(file_path))
-                if not content.startswith("Error") and not content.startswith("File not found"):
-                    matches = list(pattern.finditer(content))
-                    if matches:
-                        file_results = [f"\n### {v}/{file} ({len(matches)} matches):\n"]
-
-                        for i, match in enumerate(matches[:5]):  # Limit to 5 matches per file
-                            start = max(0, match.start() - context_length)
-                            end = min(len(content), match.end() + context_length)
-
-                            # Find line boundaries
-                            while start > 0 and content[start] != '\n':
-                                start -= 1
-                            while end < len(content) and content[end] != '\n':
-                                end += 1
-
-                            context = content[start:end].strip()
-                            # Highlight the match
-                            context = pattern.sub(lambda m: f"**{m.group()}**", context)
-
-                            file_results.append(f"Match {i+1}:\n```\n{context}\n```\n")
-
-                        results.extend(file_results)
-        
-        # Search external documentation if requested
-        if include_external and external_dir and external_dir.exists():
-            for service_dir in external_dir.iterdir():
-                if service_dir.is_dir():
-                    service_name = service_dir.name
-                    
-                    for file_path in service_dir.glob("*.md"):
-                        try:
-                            content = get_file_content_cached(str(file_path))
-                            if not content.startswith("Error") and not content.startswith("File not found"):
-                                matches = list(pattern.finditer(content))
-                                if matches:
-                                    file_results = [f"\n### {service_name.title()}/{file_path.name} ({len(matches)} matches):\n"]
-                                    
-                                    for i, match in enumerate(matches[:5]):
-                                        start = max(0, match.start() - context_length)
-                                        end = min(len(content), match.end() + context_length)
-                                        
-                                        while start > 0 and content[start] != '\n':
-                                            start -= 1
-                                        while end < len(content) and content[end] != '\n':
-                                            end += 1
-                                        
-                                        context = content[start:end].strip()
-                                        context = pattern.sub(lambda m: f"**{m.group()}**", context)
-                                        
-                                        file_results.append(f"Match {i+1}:\n```\n{context}\n```\n")
-                                    
-                                    results.extend(file_results)
-                        except Exception as e:
-                            logger.warning(f"Error searching {file_path}: {str(e)}")
-                            continue
-        
-        if results:
-            return f"Search results for '{query}':\n" + "".join(results)
-        else:
-            search_scope = f"version {version}" if version else f"versions {', '.join(search_versions)}"
-            return f"No results found for '{query}' in {search_scope}"
-            
-    except Exception as e:
-        logger.error(f"Error searching documentation: {str(e)}")
-        return f"Error searching documentation: {str(e)}"
 
 
 def get_doc_structure_impl(docs_path: Path, filename: str, version: Optional[str] = None, runtime_version: Optional[str] = None) -> str:

--- a/mcp_tools.py
+++ b/mcp_tools.py
@@ -535,6 +535,59 @@ def read_laravel_doc_content_impl(docs_path: Path, filename: str, version: Optio
         return f"Error reading file: {str(e)}"
 
 
+def read_laravel_doc_section_impl(
+    docs_path: Path,
+    filename: str,
+    section: str,
+    version: Optional[str] = None,
+    runtime_version: Optional[str] = None,
+) -> str:
+    """Return one ## section of a documentation file.
+
+    `section` matches either the anchor or the heading text, case-insensitively.
+    Search output shows both, and the caller should not have to guess which one
+    is canonical.
+
+    This exists because whole-file reads are the dominant cost of answering a
+    question: queues.md alone is around 34,000 tokens, of which a typical answer
+    needs a small fraction.
+    """
+    version_error = validate_version(version)
+    if version_error:
+        return version_error
+
+    if not version:
+        version = runtime_version if runtime_version else DEFAULT_VERSION
+
+    if not filename.endswith('.md'):
+        filename = f"{filename}.md"
+
+    version_path = Path(docs_path) / version
+    safe_path = resolve_contained_path(version_path, version_path / filename)
+    if safe_path is None:
+        logger.warning(f"Access denied: {filename} (attempted directory traversal)")
+        return f"Access denied: {filename} (attempted directory traversal)"
+
+    if not safe_path.exists():
+        return f"Documentation file not found: {filename} (version: {version})"
+
+    content = get_file_content_cached(str(safe_path))
+    if content.startswith("Error") or content.startswith("File not found"):
+        return content
+
+    wanted = section.strip().lower().lstrip('#')
+    sections = chunk_markdown(content, filename, version)
+
+    for candidate in sections:
+        if (candidate.anchor or "").lower() == wanted or candidate.heading.lower() == wanted:
+            return candidate.text.strip()
+
+    return format_error(
+        f"Section '{section}' not found in {filename}",
+        {"available_sections": [s.anchor or s.heading for s in sections]},
+    )
+
+
 def search_laravel_docs_impl(
     docs_path: Path,
     query: str,

--- a/mcp_tools.py
+++ b/mcp_tools.py
@@ -66,15 +66,38 @@ _search_result_cache: Dict[str, str] = {}
 _cache_lock = threading.Lock()
 
 
+def _no_follow_opener(path, flags):
+    """open() opener that refuses to follow a symlink in the final component.
+
+    Passed to open() rather than calling os.open directly so that the read still
+    goes through the normal open(), which keeps the behaviour observable to
+    callers and testable in the usual way.
+
+    O_NOFOLLOW is POSIX. Where it is unavailable this degrades to an ordinary
+    open rather than refusing to read anything.
+    """
+    return os.open(path, flags | getattr(os, "O_NOFOLLOW", 0))
+
+
 def get_file_content_cached(file_path: str) -> str:
-    """Get file content with caching."""
+    """Get file content with caching.
+
+    Refuses to open a path whose final component is a symbolic link. Containment
+    is checked before the open, and a path that is a regular file when checked
+    can be replaced by a link before it is opened -- resolving first does not
+    help, because a regular file resolves to itself. O_NOFOLLOW closes that
+    window by making the refusal part of the open itself.
+
+    Callers that legitimately want a linked file should resolve it first (see
+    resolve_contained_path) and pass the resolved path, which is not a link.
+    """
     with _cache_lock:
         if file_path in _file_content_cache:
             logger.debug(f"Cache hit for file: {file_path}")
             return _file_content_cache[file_path]
 
     try:
-        with open(file_path, 'r', encoding='utf-8') as f:
+        with open(file_path, 'r', encoding='utf-8', opener=_no_follow_opener) as f:
             content = f.read()
 
         # Cache the content
@@ -115,40 +138,72 @@ def get_version_from_path(path: str, runtime_version: Optional[str] = None) -> t
         return default_version, path
 
 
-def is_safe_path(base_path: Path, target_path: Path) -> bool:
-    """Check if target path is within base path (prevent directory traversal).
+def resolve_contained_path(base_path: Path, target_path: Path) -> Optional[Path]:
+    """Resolve target_path, returning it only if it lands inside base_path.
 
-    Uses is_relative_to() on fully resolved paths. A plain string prefix check is
-    not sufficient: it treats "/docs/12.x-backup" as living under "/docs/12.x".
+    Callers must read the path this returns, not the one they passed in.
+    Validating one path and then opening another leaves a window in which a
+    symlink can be swapped between the check and the open, so the file that was
+    approved and the file that gets read need not be the same one.
 
-    Fails closed: any error resolving either path denies access.
+    Uses is_relative_to() on fully resolved paths. A plain string prefix check
+    is not sufficient: it treats "/docs/12.x-backup" as living under "/docs/12.x".
+
+    Returns None if the path escapes, or if either path cannot be resolved --
+    any error denies access.
     """
     try:
-        return Path(target_path).resolve().is_relative_to(Path(base_path).resolve())
+        base = Path(base_path).resolve()
+        resolved = Path(target_path).resolve()
     except Exception:
-        return False
+        return None
+    return resolved if resolved.is_relative_to(base) else None
 
 
-def list_contained_markdown(version_path: Path) -> List[str]:
-    """List .md filenames in version_path that actually resolve inside it.
+def is_safe_path(base_path: Path, target_path: Path) -> bool:
+    """Whether target_path resolves to a location inside base_path.
+
+    Prefer resolve_contained_path when the caller goes on to read the file, so
+    that the path checked is the path opened.
+    """
+    return resolve_contained_path(base_path, target_path) is not None
+
+
+def list_contained_markdown(version_path: Path) -> List[tuple[str, Path]]:
+    """Return (name, readable_path) for .md files that stay inside version_path.
 
     Enumeration has to apply the same containment rule as reading. Without it a
     symlink pointing out of the tree is listed and searched while
     read_laravel_doc_content refuses to serve it -- which turns search into an
     oracle over content the read path deliberately withholds.
+
+    The second element is the path callers should read: for a symlink it is the
+    resolved target, since the reader refuses to follow links at open time.
+
+    Only symlinks are resolved. A plain file that is a direct child of
+    version_path cannot escape it, and resolving every file turned a search over
+    the corpus into hundreds of unnecessary readlink walks.
     """
     # Errors are deliberately not swallowed. An unreadable documentation
     # directory must surface as an error, not as "no files found" -- the callers
     # already wrap this and turn exceptions into a message.
+    contained: List[tuple[str, Path]] = []
     with os.scandir(version_path) as entries:
-        names = [e.name for e in entries if e.name.endswith('.md')]
+        for entry in entries:
+            if not entry.name.endswith('.md'):
+                continue
 
-    contained = []
-    for name in names:
-        if is_safe_path(version_path, version_path / name):
-            contained.append(name)
-        else:
-            logger.warning(f"Skipping documentation file outside its version directory: {name}")
+            if not entry.is_symlink():
+                contained.append((entry.name, Path(entry.path)))
+                continue
+
+            resolved = resolve_contained_path(version_path, Path(entry.path))
+            if resolved is not None:
+                contained.append((entry.name, resolved))
+            else:
+                logger.warning(
+                    f"Skipping documentation file outside its version directory: {entry.name}"
+                )
     return contained
 
 
@@ -349,7 +404,7 @@ def list_laravel_docs_impl(docs_path: Path, version: Optional[str] = None, runti
                 )
 
             metadata = get_laravel_docs_metadata(docs_path, version)
-            md_files = sorted(list_contained_markdown(version_path))
+            md_files = sorted(name for name, _ in list_contained_markdown(version_path))
 
             if not md_files:
                 return format_error(f"No documentation files found in version {version}")
@@ -368,7 +423,7 @@ def list_laravel_docs_impl(docs_path: Path, version: Optional[str] = None, runti
                 version_path = docs_path / v
                 if not version_path.is_dir():
                     continue
-                md_files = list_contained_markdown(version_path)
+                md_files = [name for name, _ in list_contained_markdown(version_path)]
                 if md_files:
                     metadata = get_laravel_docs_metadata(docs_path, v)
                     versions_data.append({
@@ -421,23 +476,26 @@ def read_laravel_doc_content_impl(docs_path: Path, filename: str, version: Optio
     
     file_path = docs_path / version / relative_path
     
-    # Security check - ensure we stay within version directory
+    # Security check - ensure we stay within version directory. Read the
+    # resolved path this returns, not file_path: opening the unresolved path
+    # would follow the symlink a second time, after the check.
     version_path = docs_path / version
-    if not is_safe_path(version_path, file_path):
+    safe_path = resolve_contained_path(version_path, file_path)
+    if safe_path is None:
         logger.warning(f"Access denied: {filename} (attempted directory traversal)")
         return f"Access denied: {filename} (attempted directory traversal)"
-    
-    if not file_path.exists():
-        logger.warning(f"Documentation file not found: {file_path}")
+
+    if not safe_path.exists():
+        logger.warning(f"Documentation file not found: {safe_path}")
         return f"Documentation file not found: {filename} (version: {version})"
-    
+
     try:
-        content = get_file_content_cached(str(file_path))
+        content = get_file_content_cached(str(safe_path))
         if not content.startswith("Error") and not content.startswith("File not found"):
-            logger.debug(f"Successfully read file: {file_path} ({len(content)} bytes)")
+            logger.debug(f"Successfully read file: {safe_path} ({len(content)} bytes)")
         return content
     except Exception as e:
-        logger.error(f"Error reading file {file_path}: {str(e)}")
+        logger.error(f"Error reading file {safe_path}: {str(e)}")
         return f"Error reading file: {str(e)}"
 
 
@@ -484,9 +542,7 @@ def search_laravel_docs_impl(docs_path: Path, query: str, version: Optional[str]
             if not version_path.exists():
                 continue
 
-            for file in list_contained_markdown(version_path):
-                file_path = version_path / file
-
+            for file, file_path in list_contained_markdown(version_path):
                 content = get_file_content_cached(str(file_path))
                 if not content.startswith("Error") and not content.startswith("File not found"):
                     count = count_matches(pattern, content)
@@ -580,9 +636,7 @@ def search_laravel_docs_with_context_impl(docs_path: Path, query: str, version: 
             if not version_path.exists():
                 continue
             
-            for file in list_contained_markdown(version_path):
-                file_path = version_path / file
-
+            for file, file_path in list_contained_markdown(version_path):
                 content = get_file_content_cached(str(file_path))
                 if not content.startswith("Error") and not content.startswith("File not found"):
                     matches = list(pattern.finditer(content))

--- a/mcp_tools.py
+++ b/mcp_tools.py
@@ -15,6 +15,7 @@ from typing import Dict, List, Optional
 import json
 import threading
 
+from doc_search import Section, chunk_markdown
 from docs_updater import get_cached_supported_versions, DEFAULT_VERSION
 from toon_helpers import (
     toon_encode,
@@ -205,6 +206,41 @@ def list_contained_markdown(version_path: Path) -> List[tuple[str, Path]]:
                     f"Skipping documentation file outside its version directory: {entry.name}"
                 )
     return contained
+
+
+def load_version_sections(docs_path: Path, version: str) -> List["Section"]:
+    """Chunk every contained markdown file of a version into sections.
+
+    Enumeration goes through list_contained_markdown and reads through
+    get_file_content_cached, so containment and the refusal to follow symlinks
+    at open time both carry over unchanged rather than being reimplemented.
+    """
+    version_path = Path(docs_path) / version
+    if not version_path.is_dir():
+        return []
+
+    sections: List["Section"] = []
+    for name, path in list_contained_markdown(version_path):
+        content = get_file_content_cached(str(path))
+        if content.startswith("Error") or content.startswith("File not found"):
+            continue
+        sections.extend(chunk_markdown(content, name, version))
+    return sections
+
+
+def load_service_sections(external_dir: Path, service: str) -> List["Section"]:
+    """Chunk an external service's documentation, keyed by service name."""
+    service_path = Path(external_dir) / service
+    if not service_path.is_dir():
+        return []
+
+    sections: List["Section"] = []
+    for name, path in list_contained_markdown(service_path):
+        content = get_file_content_cached(str(path))
+        if content.startswith("Error") or content.startswith("File not found"):
+            continue
+        sections.extend(chunk_markdown(content, name, service))
+    return sections
 
 
 def validate_version(version: Optional[str]) -> Optional[str]:

--- a/mcp_tools.py
+++ b/mcp_tools.py
@@ -129,6 +129,29 @@ def is_safe_path(base_path: Path, target_path: Path) -> bool:
         return False
 
 
+def list_contained_markdown(version_path: Path) -> List[str]:
+    """List .md filenames in version_path that actually resolve inside it.
+
+    Enumeration has to apply the same containment rule as reading. Without it a
+    symlink pointing out of the tree is listed and searched while
+    read_laravel_doc_content refuses to serve it -- which turns search into an
+    oracle over content the read path deliberately withholds.
+    """
+    # Errors are deliberately not swallowed. An unreadable documentation
+    # directory must surface as an error, not as "no files found" -- the callers
+    # already wrap this and turn exceptions into a message.
+    with os.scandir(version_path) as entries:
+        names = [e.name for e in entries if e.name.endswith('.md')]
+
+    contained = []
+    for name in names:
+        if is_safe_path(version_path, version_path / name):
+            contained.append(name)
+        else:
+            logger.warning(f"Skipping documentation file outside its version directory: {name}")
+    return contained
+
+
 def validate_version(version: Optional[str]) -> Optional[str]:
     """Validate a caller-supplied Laravel version against the supported allowlist.
 
@@ -183,8 +206,17 @@ def validate_subdirectory(base_dir: Path, name: str) -> bool:
     """
     if not name or '/' in name or '\\' in name or name in ('.', '..') or '\x00' in name:
         return False
+
     candidate = base_dir / name
-    return is_safe_path(base_dir, candidate) and candidate.is_dir()
+    # Compare the parent rather than resolving the candidate. The name checks
+    # above already guarantee a single path component, so this cannot traverse;
+    # resolving instead rejected directories the operator had deliberately
+    # relocated via symlink, which listing and search both accepted -- the same
+    # inconsistency that DocsUpdater had for version directories.
+    try:
+        return candidate.parent.resolve() == base_dir.resolve() and candidate.is_dir()
+    except (OSError, ValueError):
+        return False
 
 
 # Documentation is shipped as a snapshot, so it ages. Past this many days we
@@ -317,7 +349,7 @@ def list_laravel_docs_impl(docs_path: Path, version: Optional[str] = None, runti
                 )
 
             metadata = get_laravel_docs_metadata(docs_path, version)
-            md_files = sorted([f for f in os.listdir(version_path) if f.endswith('.md')])
+            md_files = sorted(list_contained_markdown(version_path))
 
             if not md_files:
                 return format_error(f"No documentation files found in version {version}")
@@ -336,9 +368,7 @@ def list_laravel_docs_impl(docs_path: Path, version: Optional[str] = None, runti
                 version_path = docs_path / v
                 if not version_path.is_dir():
                     continue
-                # Single scandir pass instead of two listdir calls plus a stat per file
-                with os.scandir(version_path) as entries:
-                    md_files = [e.name for e in entries if e.name.endswith('.md') and e.is_file()]
+                md_files = list_contained_markdown(version_path)
                 if md_files:
                     metadata = get_laravel_docs_metadata(docs_path, v)
                     versions_data.append({
@@ -454,18 +484,17 @@ def search_laravel_docs_impl(docs_path: Path, query: str, version: Optional[str]
             if not version_path.exists():
                 continue
 
-            for file in os.listdir(version_path):
-                if file.endswith('.md'):
-                    file_path = version_path / file
+            for file in list_contained_markdown(version_path):
+                file_path = version_path / file
 
-                    content = get_file_content_cached(str(file_path))
-                    if not content.startswith("Error") and not content.startswith("File not found"):
-                        count = count_matches(pattern, content)
-                        if count:
-                            core_results_data.append({
-                                "file": f"{v}/{file}",
-                                "matches": count
-                            })
+                content = get_file_content_cached(str(file_path))
+                if not content.startswith("Error") and not content.startswith("File not found"):
+                    count = count_matches(pattern, content)
+                    if count:
+                        core_results_data.append({
+                            "file": f"{v}/{file}",
+                            "matches": count
+                        })
 
         # Search external documentation if requested
         if include_external and external_dir and external_dir.exists():
@@ -551,33 +580,32 @@ def search_laravel_docs_with_context_impl(docs_path: Path, query: str, version: 
             if not version_path.exists():
                 continue
             
-            for file in os.listdir(version_path):
-                if file.endswith('.md'):
-                    file_path = version_path / file
-                    
-                    content = get_file_content_cached(str(file_path))
-                    if not content.startswith("Error") and not content.startswith("File not found"):
-                        matches = list(pattern.finditer(content))
-                        if matches:
-                            file_results = [f"\n### {v}/{file} ({len(matches)} matches):\n"]
-                            
-                            for i, match in enumerate(matches[:5]):  # Limit to 5 matches per file
-                                start = max(0, match.start() - context_length)
-                                end = min(len(content), match.end() + context_length)
-                                
-                                # Find line boundaries
-                                while start > 0 and content[start] != '\n':
-                                    start -= 1
-                                while end < len(content) and content[end] != '\n':
-                                    end += 1
-                                
-                                context = content[start:end].strip()
-                                # Highlight the match
-                                context = pattern.sub(lambda m: f"**{m.group()}**", context)
-                                
-                                file_results.append(f"Match {i+1}:\n```\n{context}\n```\n")
-                            
-                            results.extend(file_results)
+            for file in list_contained_markdown(version_path):
+                file_path = version_path / file
+
+                content = get_file_content_cached(str(file_path))
+                if not content.startswith("Error") and not content.startswith("File not found"):
+                    matches = list(pattern.finditer(content))
+                    if matches:
+                        file_results = [f"\n### {v}/{file} ({len(matches)} matches):\n"]
+
+                        for i, match in enumerate(matches[:5]):  # Limit to 5 matches per file
+                            start = max(0, match.start() - context_length)
+                            end = min(len(content), match.end() + context_length)
+
+                            # Find line boundaries
+                            while start > 0 and content[start] != '\n':
+                                start -= 1
+                            while end < len(content) and content[end] != '\n':
+                                end += 1
+
+                            context = content[start:end].strip()
+                            # Highlight the match
+                            context = pattern.sub(lambda m: f"**{m.group()}**", context)
+
+                            file_results.append(f"Match {i+1}:\n```\n{context}\n```\n")
+
+                        results.extend(file_results)
         
         # Search external documentation if requested
         if include_external and external_dir and external_dir.exists():

--- a/tests/integration/test_complete_workflows.py
+++ b/tests/integration/test_complete_workflows.py
@@ -276,8 +276,8 @@ class TestCachingWorkflows:
             
             # Second search with same query - should use cache
             # We can verify by checking the cache directly
-            # The cache key format is "search:query:version:include_external"
-            cache_key = "search:keyword:12.x:True"
+            # Key includes the result limit, which changes the response
+            cache_key = "search:keyword:12.x:True:5"
             assert cache_key in _search_result_cache
             cached_result = _search_result_cache[cache_key]
             assert "test.md" in cached_result

--- a/tests/unit/test_cache_management.py
+++ b/tests/unit/test_cache_management.py
@@ -102,7 +102,7 @@ class TestCacheManagement:
                 
                 # First 20 should be removed
                 for i in range(20):
-                    cache_key = f"search:query{i}:11.x:True"
+                    cache_key = f"search:query{i}:11.x:True:5"
                     assert cache_key not in _search_result_cache
     
     def test_concurrent_cache_access(self):
@@ -261,11 +261,11 @@ class TestCacheManagement:
             default_scope = ','.join(resolve_search_versions(None))
             all_scope = ','.join(resolve_search_versions(None, all_versions=True))
 
-            assert "search:test:11.x:True" in _search_result_cache
-            assert "search:test:11.x:False" in _search_result_cache
-            assert f"search:test:{default_scope}:True" in _search_result_cache
+            assert "search:test:11.x:True:5" in _search_result_cache
+            assert "search:test:11.x:False:5" in _search_result_cache
+            assert f"search:test:{default_scope}:True:5" in _search_result_cache
             # Scoped and all-versions searches must not share a cache entry
-            assert f"search:test:{all_scope}:True" in _search_result_cache
+            assert f"search:test:{all_scope}:True:5" in _search_result_cache
             assert default_scope != all_scope
     
     def test_clear_caches_function(self):

--- a/tests/unit/test_containment_consistency.py
+++ b/tests/unit/test_containment_consistency.py
@@ -189,3 +189,98 @@ class TestLearningResourceSymlinkConsistency:
             learning_with_symlinked_source, source="tutorials"
         )
         assert "intro.md" in result
+
+
+class TestOpensThePathItValidated:
+    """The containment check must hand back the path the caller then opens.
+
+    `is_safe_path` resolved the target, threw the resolved value away, and the
+    caller opened the original. Between those two steps a symlink can be
+    swapped, so the path that was checked and the path that was opened are not
+    guaranteed to be the same file. Resolving once and opening that result
+    closes the window.
+    """
+
+    def test_read_opens_the_resolved_target_not_the_link(self, tmp_path):
+        from unittest.mock import patch
+
+        from mcp_tools import read_laravel_doc_content_impl
+
+        docs = tmp_path / "docs"
+        version_dir = docs / VERSION
+        version_dir.mkdir(parents=True)
+        (version_dir / "real.md").write_text("# Real\n\ncontent")
+        os.symlink(version_dir / "real.md", version_dir / "alias.md")
+
+        with patch("mcp_tools.get_file_content_cached", return_value="# Real") as reader:
+            read_laravel_doc_content_impl(docs, "alias.md", VERSION)
+
+        opened = os.path.basename(reader.call_args[0][0])
+        assert opened == "real.md", (
+            f"opened {opened!r}; must open the resolved path that was validated, "
+            "not the link that was validated through"
+        )
+
+    def test_resolved_contained_path_returns_the_resolution(self, tmp_path):
+        from mcp_tools import resolve_contained_path
+
+        base = tmp_path / "base"
+        base.mkdir()
+        (base / "real.md").write_text("x")
+        os.symlink(base / "real.md", base / "alias.md")
+
+        resolved = resolve_contained_path(base, base / "alias.md")
+
+        assert resolved is not None
+        assert resolved.name == "real.md", "must return what the path resolves to"
+
+    def test_resolved_contained_path_rejects_escapes(self, tmp_path):
+        from mcp_tools import resolve_contained_path
+
+        base = tmp_path / "base"
+        base.mkdir()
+        outside = tmp_path / "outside.md"
+        outside.write_text("secret")
+        os.symlink(outside, base / "escape.md")
+
+        assert resolve_contained_path(base, base / "escape.md") is None
+        assert resolve_contained_path(base, base / ".." / "outside.md") is None
+
+    def test_resolved_contained_path_fails_closed(self):
+        from mcp_tools import resolve_contained_path
+
+        assert resolve_contained_path(None, None) is None
+
+
+class TestReaderRefusesToFollowLinks:
+    """Resolving before opening is necessary but not sufficient.
+
+    A path that is a regular file when checked can be replaced by a symlink
+    before it is opened, and the open follows it. Resolving first does not help
+    -- a regular file resolves to itself. Only refusing to follow a link at open
+    time closes that window, because the refusal is part of the open itself.
+    """
+
+    def test_reader_refuses_a_symlink(self, tmp_path):
+        from mcp_tools import clear_caches, get_file_content_cached
+
+        secret = tmp_path / "secret.md"
+        secret.write_text("TOCTOU-CANARY-7712")
+        link = tmp_path / "link.md"
+        os.symlink(secret, link)
+
+        clear_caches()
+        content = get_file_content_cached(str(link))
+
+        assert "TOCTOU-CANARY-7712" not in content, "followed a symlink at open time"
+
+    def test_reader_still_reads_regular_files(self, tmp_path):
+        from mcp_tools import clear_caches, get_file_content_cached
+
+        regular = tmp_path / "regular.md"
+        regular.write_text("# Regular\n\nordinary content")
+
+        clear_caches()
+        content = get_file_content_cached(str(regular))
+
+        assert "ordinary content" in content

--- a/tests/unit/test_containment_consistency.py
+++ b/tests/unit/test_containment_consistency.py
@@ -1,0 +1,191 @@
+"""Every path that touches a documentation file must agree on containment.
+
+`read_laravel_doc_content` refuses a file that resolves outside its version
+directory. The enumeration paths -- listing and searching -- did not check at
+all, so the same symlinked file was denied on read while being listed and
+match-counted. That disagreement is a content oracle over material the read
+path explicitly refuses to serve.
+"""
+
+import os
+
+import pytest
+
+from mcp_tools import (
+    SUPPORTED_VERSIONS,
+    list_laravel_docs_impl,
+    read_laravel_doc_content_impl,
+    search_laravel_docs_impl,
+    search_laravel_docs_with_context_impl,
+)
+
+# The term searched for. It is echoed back in "no results" messages, so it
+# cannot double as the leak canary.
+QUERY = "OUTSIDE-CANARY-content"
+# Text that only ever appears inside the out-of-tree file. Its presence in any
+# response means real content escaped, not just the query being echoed.
+PAYLOAD = "SENSITIVE-PAYLOAD-4417"
+VERSION = SUPPORTED_VERSIONS[-1]
+
+
+@pytest.fixture
+def docs_with_escaping_symlink(tmp_path):
+    """A version directory containing a symlink that points outside the tree."""
+    docs = tmp_path / "docs"
+    version_dir = docs / VERSION
+    version_dir.mkdir(parents=True)
+    (version_dir / "blade.md").write_text("# Blade\n\nLegitimate content.")
+
+    outside = tmp_path / "outside.md"
+    outside.write_text(f"# Secret\n\n{QUERY} {PAYLOAD}")
+    os.symlink(outside, version_dir / "routing.md")
+
+    return docs
+
+
+def test_read_refuses_the_escaping_symlink(docs_with_escaping_symlink):
+    """Baseline: this is the behavior the other paths must match."""
+    result = read_laravel_doc_content_impl(docs_with_escaping_symlink, "routing.md", VERSION)
+
+    assert PAYLOAD not in result
+    assert "Access denied" in result
+
+
+def test_list_does_not_advertise_the_escaping_symlink(docs_with_escaping_symlink):
+    result = list_laravel_docs_impl(docs_with_escaping_symlink, version=VERSION)
+
+    assert "routing.md" not in result, "listed a file that read refuses to serve"
+    assert "blade.md" in result, "legitimate files must still be listed"
+
+
+def test_search_does_not_match_inside_the_escaping_symlink(docs_with_escaping_symlink):
+    result = search_laravel_docs_impl(
+        docs_with_escaping_symlink, QUERY, version=VERSION, include_external=False
+    )
+
+    assert "routing.md" not in result, "match-counted a file that read refuses to serve"
+
+
+def test_context_search_does_not_leak_the_escaping_symlink(docs_with_escaping_symlink):
+    result = search_laravel_docs_with_context_impl(
+        docs_with_escaping_symlink, QUERY, version=VERSION, include_external=False
+    )
+
+    assert PAYLOAD not in result, "leaked content that read refuses to serve"
+    assert "routing.md" not in result
+
+
+def test_legitimate_search_still_works(docs_with_escaping_symlink):
+    """The containment filter must not break ordinary searching."""
+    result = search_laravel_docs_impl(
+        docs_with_escaping_symlink, "Legitimate", version=VERSION, include_external=False
+    )
+
+    assert "blade.md" in result
+
+
+class TestAllowedHostWildcard:
+    """`ALLOWED_HOSTS=*` must not silently disable the Host guard.
+
+    FastMCP matches allowed hosts with fnmatchcase, so a wildcard entry matches
+    every Host header — turning off DNS-rebinding protection while the operator
+    sees a configured allowlist. Wildcard CORS origins are already rejected;
+    hosts were not.
+    """
+
+    def _parse(self, monkeypatch, argv, env):
+        import sys
+        from laravel_mcp_companion import parse_arguments
+
+        for var in ("CORS_ORIGINS", "ALLOWED_HOSTS"):
+            monkeypatch.delenv(var, raising=False)
+        for key, value in env.items():
+            monkeypatch.setenv(key, value)
+        monkeypatch.setattr(sys, "argv", ["prog"] + argv)
+        return parse_arguments()
+
+    @pytest.mark.parametrize("wildcard", ["*", "*.example.com", "foo*"])
+    def test_wildcard_host_is_rejected_from_cli(self, monkeypatch, wildcard):
+        with pytest.raises(SystemExit):
+            self._parse(monkeypatch, ["--allowed-host", wildcard], {})
+
+    def test_wildcard_host_is_rejected_from_env(self, monkeypatch):
+        """The env path must be checked too; argparse does not validate defaults."""
+        with pytest.raises(SystemExit):
+            self._parse(monkeypatch, [], {"ALLOWED_HOSTS": "good.example,*"})
+
+    def test_literal_hosts_are_accepted(self, monkeypatch):
+        args = self._parse(
+            monkeypatch, ["--allowed-host", "mcp.internal.example"], {}
+        )
+        assert args.allowed_host == ["mcp.internal.example"]
+
+
+class TestLearningResourceSymlinkConsistency:
+    """Scoped and unscoped learning-resource access must give the same answer.
+
+    `validate_subdirectory` resolves through symlinks, so a symlinked source was
+    reported "not found" while simultaneously appearing in the available-sources
+    list, and an unscoped search read it anyway. Whichever answer is right, all
+    three paths have to give it.
+    """
+
+    @pytest.fixture
+    def learning_with_symlinked_source(self, tmp_path):
+        docs = tmp_path / "docs"
+        learning = docs / "learning_resources"
+        learning.mkdir(parents=True)
+
+        # A real source, and one relocated elsewhere via symlink
+        (learning / "tutorials").mkdir()
+        (learning / "tutorials" / "intro.md").write_text("# Intro\n\nreal source")
+
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        (elsewhere / "guide.md").write_text(f"# Guide\n\n{PAYLOAD}")
+        os.symlink(elsewhere, learning / "bootcamp")
+
+        return docs
+
+    def test_listing_a_source_agrees_with_listing_all(self, learning_with_symlinked_source):
+        from mcp_tools import list_laravel_learning_resources_impl
+
+        all_sources = list_laravel_learning_resources_impl(learning_with_symlinked_source)
+        scoped = list_laravel_learning_resources_impl(
+            learning_with_symlinked_source, source="bootcamp"
+        )
+
+        advertised = "bootcamp" in all_sources
+        readable = "not found" not in scoped
+
+        assert advertised == readable, (
+            "a source listed as available must be readable, and vice versa; "
+            f"advertised={advertised} readable={readable}"
+        )
+
+    def test_search_agrees_with_listing(self, learning_with_symlinked_source):
+        from mcp_tools import (
+            list_laravel_learning_resources_impl,
+            search_laravel_learning_resources_impl,
+        )
+
+        all_sources = list_laravel_learning_resources_impl(learning_with_symlinked_source)
+        unscoped_search = search_laravel_learning_resources_impl(
+            learning_with_symlinked_source, PAYLOAD
+        )
+
+        advertised = "bootcamp" in all_sources
+        searched = "bootcamp" in unscoped_search
+
+        assert advertised == searched, (
+            "unscoped search must cover exactly the sources that are listed; "
+            f"advertised={advertised} searched={searched}"
+        )
+
+    def test_real_sources_are_unaffected(self, learning_with_symlinked_source):
+        from mcp_tools import list_laravel_learning_resources_impl
+
+        result = list_laravel_learning_resources_impl(
+            learning_with_symlinked_source, source="tutorials"
+        )
+        assert "intro.md" in result

--- a/tests/unit/test_containment_consistency.py
+++ b/tests/unit/test_containment_consistency.py
@@ -16,7 +16,6 @@ from mcp_tools import (
     list_laravel_docs_impl,
     read_laravel_doc_content_impl,
     search_laravel_docs_impl,
-    search_laravel_docs_with_context_impl,
 )
 
 # The term searched for. It is echoed back in "no results" messages, so it
@@ -66,8 +65,9 @@ def test_search_does_not_match_inside_the_escaping_symlink(docs_with_escaping_sy
     assert "routing.md" not in result, "match-counted a file that read refuses to serve"
 
 
-def test_context_search_does_not_leak_the_escaping_symlink(docs_with_escaping_symlink):
-    result = search_laravel_docs_with_context_impl(
+def test_search_snippets_do_not_leak_the_escaping_symlink(docs_with_escaping_symlink):
+    """Search now returns content in snippets, so a leak here is a direct one."""
+    result = search_laravel_docs_impl(
         docs_with_escaping_symlink, QUERY, version=VERSION, include_external=False
     )
 

--- a/tests/unit/test_doc_search.py
+++ b/tests/unit/test_doc_search.py
@@ -1,0 +1,54 @@
+"""Tests for section chunking, BM25 indexing and retrieval."""
+
+from doc_search import Section, chunk_markdown
+
+SAMPLE = """# Queues
+
+Intro paragraph before any section.
+
+<a name="dealing-with-failed-jobs"></a>
+## Dealing With Failed Jobs
+
+Jobs that exceed max attempts land in failed_jobs.
+
+## Max Job Attempts
+
+Use the tries property.
+"""
+
+
+def test_chunk_splits_on_h2_headings():
+    sections = chunk_markdown(SAMPLE, "queues.md", "13.x")
+    headings = [s.heading for s in sections]
+    assert "Dealing With Failed Jobs" in headings
+    assert "Max Job Attempts" in headings
+
+
+def test_chunk_captures_anchor_when_present():
+    sections = chunk_markdown(SAMPLE, "queues.md", "13.x")
+    failed = next(s for s in sections if s.heading == "Dealing With Failed Jobs")
+    assert failed.anchor == "dealing-with-failed-jobs"
+
+
+def test_chunk_leaves_anchor_none_when_absent():
+    sections = chunk_markdown(SAMPLE, "queues.md", "13.x")
+    attempts = next(s for s in sections if s.heading == "Max Job Attempts")
+    assert attempts.anchor is None
+
+
+def test_chunk_keeps_preamble_before_first_heading():
+    sections = chunk_markdown(SAMPLE, "queues.md", "13.x")
+    assert any("Intro paragraph" in s.text for s in sections)
+
+
+def test_chunk_file_with_no_h2_returns_one_section():
+    sections = chunk_markdown("# Title\n\nBody only.\n", "solo.md", "13.x")
+    assert len(sections) == 1
+    assert "Body only." in sections[0].text
+
+
+def test_chunk_records_provenance():
+    sections = chunk_markdown(SAMPLE, "queues.md", "13.x")
+    assert all(s.filename == "queues.md" for s in sections)
+    assert all(s.version == "13.x" for s in sections)
+    assert isinstance(sections[0], Section)

--- a/tests/unit/test_doc_search.py
+++ b/tests/unit/test_doc_search.py
@@ -200,3 +200,57 @@ def test_clear_caches_also_clears_indexes():
 
     clear_caches()
     assert resident_index_count() == 0
+
+
+def test_load_version_sections_reads_real_files(tmp_path):
+    from mcp_tools import SUPPORTED_VERSIONS, load_version_sections
+
+    version = SUPPORTED_VERSIONS[-1]
+    docs = tmp_path / "docs"
+    (docs / version).mkdir(parents=True)
+    (docs / version / "queues.md").write_text(
+        "# Queues\n\n## Failed Jobs\n\nRetry them with queue:retry.\n"
+    )
+
+    sections = load_version_sections(docs, version)
+
+    assert any(s.heading == "Failed Jobs" for s in sections)
+    assert all(s.filename == "queues.md" for s in sections)
+
+
+def test_load_version_sections_skips_escaping_symlinks(tmp_path):
+    """Containment behaviour must match the read path."""
+    import os
+
+    from mcp_tools import SUPPORTED_VERSIONS, load_version_sections
+
+    version = SUPPORTED_VERSIONS[-1]
+    docs = tmp_path / "docs"
+    (docs / version).mkdir(parents=True)
+    (docs / version / "real.md").write_text("## Real\n\ncontent\n")
+    outside = tmp_path / "outside.md"
+    outside.write_text("## Secret\n\nCANARY-9021\n")
+    os.symlink(outside, docs / version / "escape.md")
+
+    sections = load_version_sections(docs, version)
+
+    assert not any("CANARY-9021" in s.text for s in sections)
+
+
+def test_load_version_sections_of_missing_version_is_empty(tmp_path):
+    from mcp_tools import SUPPORTED_VERSIONS, load_version_sections
+
+    assert load_version_sections(tmp_path, SUPPORTED_VERSIONS[-1]) == []
+
+
+def test_load_service_sections_keys_by_service(tmp_path):
+    from mcp_tools import load_service_sections
+
+    external = tmp_path / "external"
+    (external / "forge").mkdir(parents=True)
+    (external / "forge" / "intro.md").write_text("## Provisioning\n\nServer setup.\n")
+
+    sections = load_service_sections(external, "forge")
+
+    assert sections
+    assert all(s.version == "forge" for s in sections)

--- a/tests/unit/test_doc_search.py
+++ b/tests/unit/test_doc_search.py
@@ -130,3 +130,61 @@ def test_snippet_falls_back_to_the_start_when_no_term_matches():
 
 def test_snippet_of_short_text_returns_it_whole():
     assert extract_snippet("short body", "body", max_chars=300) == "short body"
+
+
+from pathlib import Path
+
+from doc_search import (
+    DocIndex,
+    MAX_RESIDENT_INDEXES,
+    clear_indexes,
+    get_index,
+    resident_index_count,
+)
+
+
+def _sections(version, *bodies):
+    out = []
+    for i, body in enumerate(bodies):
+        out.extend(chunk_markdown(f"## Heading {i}\n\n{body}\n", f"f{i}.md", version))
+    return out
+
+
+def test_docindex_returns_sections_ranked():
+    index = DocIndex(_sections("13.x", "failed jobs are retried", "blade templates"))
+    hits = index.search("retry failed jobs", top_k=2)
+    assert hits
+    assert "failed jobs" in hits[0][0].text
+
+
+def test_docindex_substring_search_finds_exact_symbols():
+    index = DocIndex(_sections("13.x", "run queue:retry to requeue", "unrelated"))
+    hits = index.substring_search("queue:retry", top_k=2)
+    assert hits
+    assert "queue:retry" in hits[0][0].text
+
+
+def test_get_index_builds_once_per_key():
+    clear_indexes()
+    calls = []
+
+    def loader():
+        calls.append(1)
+        return _sections("13.x", "queue workers")
+
+    get_index(Path("/unused"), "13.x", loader)
+    get_index(Path("/unused"), "13.x", loader)
+    assert len(calls) == 1
+
+
+def test_registry_evicts_beyond_the_cap():
+    clear_indexes()
+    for n in range(MAX_RESIDENT_INDEXES + 2):
+        get_index(Path("/unused"), f"v{n}", lambda: _sections("x", "content"))
+    assert resident_index_count() == MAX_RESIDENT_INDEXES
+
+
+def test_clear_indexes_empties_the_registry():
+    get_index(Path("/unused"), "13.x", lambda: _sections("13.x", "content"))
+    clear_indexes()
+    assert resident_index_count() == 0

--- a/tests/unit/test_doc_search.py
+++ b/tests/unit/test_doc_search.py
@@ -52,3 +52,52 @@ def test_chunk_records_provenance():
     assert all(s.filename == "queues.md" for s in sections)
     assert all(s.version == "13.x" for s in sections)
     assert isinstance(sections[0], Section)
+
+
+from doc_search import BM25Index
+
+CORPUS = [
+    "queue jobs are processed by workers and can fail",
+    "failed jobs are stored in the failed_jobs table and can be retried",
+    "blade templates render views with directives",
+]
+
+
+def test_index_ranks_the_relevant_document_first():
+    idx = BM25Index()
+    idx.build(CORPUS)
+    ranked = idx.query("retry failed jobs", top_k=3)
+    assert ranked, "expected at least one hit"
+    assert ranked[0][0] == 1
+
+
+def test_index_returns_scores_in_descending_order():
+    idx = BM25Index()
+    idx.build(CORPUS)
+    scores = [score for _, score in idx.query("jobs", top_k=3)]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_index_returns_nothing_for_unknown_terms():
+    idx = BM25Index()
+    idx.build(CORPUS)
+    assert idx.query("kubernetes helm chart", top_k=3) == []
+
+
+def test_index_handles_empty_corpus():
+    idx = BM25Index()
+    idx.build([])
+    assert idx.query("anything", top_k=3) == []
+
+
+def test_index_respects_top_k():
+    idx = BM25Index()
+    idx.build(CORPUS)
+    assert len(idx.query("jobs", top_k=1)) <= 1
+
+
+def test_index_releases_token_lists_after_build():
+    """Retaining tokenized documents is the bulk of the memory cost."""
+    idx = BM25Index()
+    idx.build(CORPUS)
+    assert not getattr(idx, "_doc_tokens", None)

--- a/tests/unit/test_doc_search.py
+++ b/tests/unit/test_doc_search.py
@@ -101,3 +101,32 @@ def test_index_releases_token_lists_after_build():
     idx = BM25Index()
     idx.build(CORPUS)
     assert not getattr(idx, "_doc_tokens", None)
+
+
+from doc_search import extract_snippet
+
+LONG = (
+    "Preamble line that is not relevant at all.\n"
+    + ("filler line\n" * 40)
+    + "Jobs that exceed their maximum attempts are inserted into the failed_jobs table.\n"
+    + ("more filler\n" * 40)
+)
+
+
+def test_snippet_centres_on_the_query_terms():
+    snippet = extract_snippet(LONG, "failed_jobs table", max_chars=200)
+    assert "failed_jobs" in snippet
+
+
+def test_snippet_respects_max_chars():
+    snippet = extract_snippet(LONG, "failed_jobs", max_chars=200)
+    assert len(snippet) <= 260
+
+
+def test_snippet_falls_back_to_the_start_when_no_term_matches():
+    snippet = extract_snippet(LONG, "kubernetes", max_chars=100)
+    assert snippet.startswith("Preamble")
+
+
+def test_snippet_of_short_text_returns_it_whole():
+    assert extract_snippet("short body", "body", max_chars=300) == "short body"

--- a/tests/unit/test_doc_search.py
+++ b/tests/unit/test_doc_search.py
@@ -254,3 +254,24 @@ def test_load_service_sections_keys_by_service(tmp_path):
 
     assert sections
     assert all(s.version == "forge" for s in sections)
+
+
+def test_snippet_returns_body_text_not_just_the_heading():
+    """A snippet that stops at the heading tells the model nothing.
+
+    The line-boundary trim must not collapse the window when the matched term
+    sits in the heading itself.
+    """
+    # A single long paragraph, as Laravel's documentation actually formats them:
+    # the only newline before the window ends is the one after the heading.
+    section = (
+        "## Dealing With Failed Jobs\n\n"
+        "Sometimes your queued jobs will fail. Jobs that exceed their configured "
+        "attempts are inserted into the failed_jobs table. Retry them with the "
+        "queue:retry Artisan command, which pushes the job back onto its original "
+        "queue so a worker may attempt it again at the next opportunity.\n"
+    )
+    snippet = extract_snippet(section, "retry failed queue job", max_chars=300)
+    assert "failed_jobs" in snippet or "queue:retry" in snippet, (
+        f"snippet carried no body: {snippet!r}"
+    )

--- a/tests/unit/test_doc_search.py
+++ b/tests/unit/test_doc_search.py
@@ -188,3 +188,15 @@ def test_clear_indexes_empties_the_registry():
     get_index(Path("/unused"), "13.x", lambda: _sections("13.x", "content"))
     clear_indexes()
     assert resident_index_count() == 0
+
+
+def test_clear_caches_also_clears_indexes():
+    """Documentation updates call clear_caches; a stale index must not survive."""
+    from mcp_tools import clear_caches
+
+    clear_indexes()
+    get_index(Path("/unused"), "13.x", lambda: _sections("13.x", "content"))
+    assert resident_index_count() == 1
+
+    clear_caches()
+    assert resident_index_count() == 0

--- a/tests/unit/test_doc_search.py
+++ b/tests/unit/test_doc_search.py
@@ -1,6 +1,19 @@
 """Tests for section chunking, BM25 indexing and retrieval."""
 
-from doc_search import Section, chunk_markdown
+from pathlib import Path
+
+from doc_search import (
+    BM25Index,
+    DocIndex,
+    MAX_RESIDENT_INDEXES,
+    Section,
+    chunk_markdown,
+    clear_indexes,
+    extract_snippet,
+    get_index,
+    resident_index_count,
+)
+
 
 SAMPLE = """# Queues
 
@@ -54,7 +67,6 @@ def test_chunk_records_provenance():
     assert isinstance(sections[0], Section)
 
 
-from doc_search import BM25Index
 
 CORPUS = [
     "queue jobs are processed by workers and can fail",
@@ -103,7 +115,6 @@ def test_index_releases_token_lists_after_build():
     assert not getattr(idx, "_doc_tokens", None)
 
 
-from doc_search import extract_snippet
 
 LONG = (
     "Preamble line that is not relevant at all.\n"
@@ -130,17 +141,6 @@ def test_snippet_falls_back_to_the_start_when_no_term_matches():
 
 def test_snippet_of_short_text_returns_it_whole():
     assert extract_snippet("short body", "body", max_chars=300) == "short body"
-
-
-from pathlib import Path
-
-from doc_search import (
-    DocIndex,
-    MAX_RESIDENT_INDEXES,
-    clear_indexes,
-    get_index,
-    resident_index_count,
-)
 
 
 def _sections(version, *bodies):

--- a/tests/unit/test_laravel_mcp_tools.py
+++ b/tests/unit/test_laravel_mcp_tools.py
@@ -5,12 +5,12 @@ from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 import laravel_mcp_companion
+from mcp_tools import is_safe_path
 from docs_updater import DEFAULT_VERSION
 from laravel_mcp_companion import (
     search_by_use_case,
     format_package_recommendation,
     get_version_from_path,
-    is_safe_path,
     get_file_content_cached,
     clear_file_cache,
     setup_docs_path,

--- a/tests/unit/test_mcp_tool_functions.py
+++ b/tests/unit/test_mcp_tool_functions.py
@@ -104,28 +104,30 @@ class TestDocumentationTools:
         
         assert result == test_content
 
-    @patch('mcp_tools.get_file_content_cached')
-    @patch('mcp_tools.os.listdir')
-    def test_search_laravel_docs_success(self, mock_listdir, mock_get_content, test_docs_dir):
-        """Test searching Laravel documentation successfully returns TOON format."""
-        # Directory already exists from fixture
+    def test_search_laravel_docs_success(self, test_docs_dir):
+        """Test searching Laravel documentation successfully returns TOON format.
 
-        # Mock file listing
-        mock_listdir.return_value = ['routing.md', 'eloquent.md']
-
-        # Mock file content
-        mock_get_content.side_effect = [
-            "# Routing\n\nLaravel routing is awesome for web applications",
+        Uses real files rather than mocking the directory listing: enumeration
+        now applies a containment check, so a mocked listing no longer reflects
+        what the search actually reads.
+        """
+        version_dir = test_docs_dir / "12.x"
+        (version_dir / "routing.md").write_text(
+            "# Routing\n\nLaravel routing is awesome for web applications"
+        )
+        (version_dir / "eloquent.md").write_text(
             "# Eloquent\n\nEloquent ORM for database routing"
-        ]
+        )
 
         with patch('mcp_tools.SUPPORTED_VERSIONS', ['12.x']):
-            result = search_laravel_docs_impl(test_docs_dir, "routing", "12.x")
+            result = search_laravel_docs_impl(
+                test_docs_dir, "routing", "12.x", include_external=False
+            )
 
             # TOON format assertions
             assert "routing" in result
-            assert "12.x/routing.md" in result or "routing.md" in result
-            assert "12.x/eloquent.md" in result or "eloquent.md" in result
+            assert "routing.md" in result
+            assert "eloquent.md" in result
 
     def test_search_laravel_docs_empty_query(self, test_docs_dir):
         """Test searching with empty query."""
@@ -381,8 +383,8 @@ class TestMcpToolsEdgeCases:
         """Test list_laravel_docs handles exceptions gracefully."""
         from mcp_tools import list_laravel_docs_impl
 
-        with patch('mcp_tools.os.listdir') as mock_listdir:
-            mock_listdir.side_effect = OSError("Permission denied")
+        with patch('mcp_tools.os.scandir') as mock_scandir:
+            mock_scandir.side_effect = OSError("Permission denied")
 
             result = list_laravel_docs_impl(test_docs_dir, "12.x")
 
@@ -466,8 +468,8 @@ class TestMcpToolsEdgeCases:
         """Test search with context handles exceptions."""
         from mcp_tools import search_laravel_docs_with_context_impl
 
-        with patch('mcp_tools.os.listdir') as mock_listdir:
-            mock_listdir.side_effect = Exception("Search error")
+        with patch('mcp_tools.os.scandir') as mock_scandir:
+            mock_scandir.side_effect = Exception("Search error")
 
             with patch('mcp_tools.SUPPORTED_VERSIONS', ['12.x']):
                 result = search_laravel_docs_with_context_impl(

--- a/tests/unit/test_mcp_tool_functions.py
+++ b/tests/unit/test_mcp_tool_functions.py
@@ -8,7 +8,6 @@ from mcp_tools import (
     list_laravel_docs_impl,
     read_laravel_doc_content_impl,
     search_laravel_docs_impl,
-    search_laravel_docs_with_context_impl,
     get_doc_structure_impl,
     browse_docs_by_category_impl,
     verify_laravel_feature_impl,
@@ -146,36 +145,6 @@ class TestDocumentationTools:
             result = search_laravel_docs_impl(test_docs_dir, "nonexistent_term", "12.x")
             
             assert "No results found for 'nonexistent_term'" in result
-
-    def test_search_laravel_docs_with_context_success(self, test_docs_dir):
-        """Test searching with context snippets."""
-        test_content = """# Laravel Routing
-
-Laravel routing is simple and powerful. You can define routes in your web.php file.
-
-## Basic Routing
-
-The most basic Laravel routes accept a URI and a closure, providing a very simple and expressive method of defining routes.
-
-```php
-Route::get('/', function () {
-    return view('welcome');
-});
-```
-
-This is how routing works in Laravel applications."""
-        
-        # Directory already exists from fixture
-        
-        with patch('mcp_tools.os.listdir', return_value=['routing.md']), \
-             patch('mcp_tools.get_file_content_cached', return_value=test_content), \
-             patch('mcp_tools.SUPPORTED_VERSIONS', ['12.x']):
-            
-            result = search_laravel_docs_with_context_impl(test_docs_dir, "routing", "12.x", context_length=100)
-            
-            assert "Search results for 'routing':" in result
-            assert "12.x/routing.md" in result
-            assert "**routing**" in result  # Highlighted match
 
     def test_get_doc_structure_success(self, test_docs_dir):
         """Test getting document structure returns TOON format."""
@@ -449,35 +418,6 @@ class TestMcpToolsEdgeCases:
                 # Should handle exception gracefully
                 # The actual implementation might return error or empty results
                 assert result is not None
-
-    def test_search_with_context_no_results(self, test_docs_dir):
-        """Test search with context returns appropriate message when no results."""
-        from mcp_tools import search_laravel_docs_with_context_impl
-
-        with patch('mcp_tools.os.listdir', return_value=['test.md']), \
-             patch('mcp_tools.get_file_content_cached', return_value="# Test\n\nNo match here"), \
-             patch('mcp_tools.SUPPORTED_VERSIONS', ['12.x']):
-
-            result = search_laravel_docs_with_context_impl(
-                test_docs_dir, "nonexistent_query_xyz", "12.x"
-            )
-
-            assert "No results found" in result
-
-    def test_search_with_context_exception(self, test_docs_dir):
-        """Test search with context handles exceptions."""
-        from mcp_tools import search_laravel_docs_with_context_impl
-
-        with patch('mcp_tools.os.scandir') as mock_scandir:
-            mock_scandir.side_effect = Exception("Search error")
-
-            with patch('mcp_tools.SUPPORTED_VERSIONS', ['12.x']):
-                result = search_laravel_docs_with_context_impl(
-                    test_docs_dir, "test", "12.x"
-                )
-
-                assert "Error" in result
-
 
 class TestVersionComparisonTools:
     """Test version comparison and feature verification tools."""

--- a/tests/unit/test_path_traversal_security.py
+++ b/tests/unit/test_path_traversal_security.py
@@ -16,7 +16,7 @@ from mcp_tools import (
     list_laravel_docs_impl,
     verify_laravel_feature_impl,
     browse_docs_by_category_impl,
-    search_laravel_docs_with_context_impl,
+    search_laravel_docs_impl,
     list_laravel_learning_resources_impl,
     search_laravel_learning_resources_impl,
 )
@@ -75,8 +75,8 @@ class TestVersionArgumentTraversal:
         assert SECRET not in result
         assert "Invalid version" in result
 
-    def test_search_with_context_rejects_traversal_version(self, docs_tree):
-        result = search_laravel_docs_with_context_impl(
+    def test_search_rejects_traversal_version(self, docs_tree):
+        result = search_laravel_docs_impl(
             docs_tree, "TOPSECRET", version="..", include_external=False
         )
         assert SECRET not in result

--- a/tests/unit/test_retrieval_quality.py
+++ b/tests/unit/test_retrieval_quality.py
@@ -1,0 +1,72 @@
+"""The retrieval regression this work exists to fix.
+
+Before this change four of these seven questions returned nothing, because the
+query was matched as a literal substring. Ranking by raw match count also placed
+queues.md 13th of 24 for "queues", behind a file with a single match.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from mcp_tools import SUPPORTED_VERSIONS, search_laravel_docs_impl
+
+VERSION = SUPPORTED_VERSIONS[-1]
+DOCS = Path("docs")
+
+QUESTIONS = [
+    "how do I validate a file upload",
+    "retry failed queue job",
+    "send email with attachment",
+    "database transactions",
+    "rate limiting api routes",
+    "eloquent relationships",
+    "queue",
+]
+
+
+@pytest.mark.parametrize("question", QUESTIONS)
+def test_realistic_questions_return_results(question):
+    result = search_laravel_docs_impl(
+        DOCS, question, version=VERSION, include_external=False
+    )
+    assert "No results" not in result, f"{question!r} returned nothing"
+
+
+def test_ranking_prefers_the_relevant_file():
+    result = search_laravel_docs_impl(
+        DOCS, "queue jobs and workers", version=VERSION, include_external=False
+    )
+    assert "queues.md" in result
+    first = [ln for ln in result.splitlines() if ".md" in ln][0]
+    assert "queues.md" in first, f"top hit was {first!r}"
+
+
+def test_search_output_stays_within_budget():
+    """A search response must not drift back toward whole-file cost."""
+    result = search_laravel_docs_impl(
+        DOCS, "retry failed queue job", version=VERSION, include_external=False
+    )
+    assert len(result) < 4800, f"{len(result)} chars exceeds the ~1,200 token budget"
+
+
+def test_results_carry_an_anchor_for_drill_down():
+    result = search_laravel_docs_impl(
+        DOCS, "retry failed queue job", version=VERSION, include_external=False
+    )
+    assert "anchor" in result
+
+
+def test_exact_symbol_lookup_falls_back_to_substring():
+    result = search_laravel_docs_impl(
+        DOCS, "queue:retry", version=VERSION, include_external=False
+    )
+    assert "No results" not in result
+
+
+def test_empty_query_is_rejected():
+    assert "cannot be empty" in search_laravel_docs_impl(DOCS, "   ", version=VERSION)
+
+
+def test_invalid_version_is_rejected():
+    assert "Invalid version" in search_laravel_docs_impl(DOCS, "queue", version="..")

--- a/tests/unit/test_retrieval_quality.py
+++ b/tests/unit/test_retrieval_quality.py
@@ -147,3 +147,28 @@ def test_read_section_costs_far_less_than_the_whole_file():
     assert len(section) < len(whole) / 5, (
         f"section {len(section)} vs whole {len(whole)} chars"
     )
+
+
+@pytest.mark.asyncio
+async def test_section_reader_is_exposed_and_context_search_retired(tmp_path):
+    from fastmcp import Client
+
+    from laravel_mcp_companion import create_mcp_server
+
+    docs = tmp_path / "docs"
+    (docs / VERSION).mkdir(parents=True)
+    (docs / VERSION / "queues.md").write_text(
+        '<a name="failed-jobs"></a>\n## Failed Jobs\n\nRetry with queue:retry.\n'
+    )
+
+    server = create_mcp_server("T", docs, VERSION, transform_mode=None)
+    async with Client(server) as client:
+        names = [t.name for t in await client.list_tools()]
+        assert "read_laravel_doc_section" in names
+        assert "search_laravel_docs_with_context" not in names
+
+        result = await client.call_tool(
+            "read_laravel_doc_section",
+            {"filename": "queues.md", "section": "failed-jobs", "version": VERSION},
+        )
+        assert "queue:retry" in result.content[0].text

--- a/tests/unit/test_retrieval_quality.py
+++ b/tests/unit/test_retrieval_quality.py
@@ -70,3 +70,80 @@ def test_empty_query_is_rejected():
 
 def test_invalid_version_is_rejected():
     assert "Invalid version" in search_laravel_docs_impl(DOCS, "queue", version="..")
+
+
+def test_read_section_by_anchor(tmp_path):
+    from mcp_tools import read_laravel_doc_section_impl
+
+    docs = tmp_path / "docs"
+    (docs / VERSION).mkdir(parents=True)
+    (docs / VERSION / "queues.md").write_text(
+        '# Queues\n\n<a name="failed-jobs"></a>\n## Failed Jobs\n\n'
+        "Retry with queue:retry.\n\n## Other\n\nUnrelated.\n"
+    )
+
+    result = read_laravel_doc_section_impl(docs, "queues.md", "failed-jobs", VERSION)
+
+    assert "queue:retry" in result
+    assert "Unrelated" not in result
+
+
+def test_read_section_by_heading_case_insensitively(tmp_path):
+    from mcp_tools import read_laravel_doc_section_impl
+
+    docs = tmp_path / "docs"
+    (docs / VERSION).mkdir(parents=True)
+    (docs / VERSION / "queues.md").write_text("## Failed Jobs\n\nRetry it.\n")
+
+    result = read_laravel_doc_section_impl(docs, "queues.md", "failed jobs", VERSION)
+
+    assert "Retry it." in result
+
+
+def test_unknown_section_lists_available_ones(tmp_path):
+    from mcp_tools import read_laravel_doc_section_impl
+
+    docs = tmp_path / "docs"
+    (docs / VERSION).mkdir(parents=True)
+    (docs / VERSION / "queues.md").write_text(
+        '<a name="failed-jobs"></a>\n## Failed Jobs\n\nBody.\n'
+    )
+
+    result = read_laravel_doc_section_impl(docs, "queues.md", "nope", VERSION)
+
+    assert "failed-jobs" in result
+
+
+def test_read_section_rejects_traversal(tmp_path):
+    from mcp_tools import read_laravel_doc_section_impl
+
+    docs = tmp_path / "docs"
+    (docs / VERSION).mkdir(parents=True)
+    (tmp_path / "secret.md").write_text("## Secret\n\nCANARY-5150\n")
+
+    result = read_laravel_doc_section_impl(docs, "../../secret.md", "secret", VERSION)
+
+    assert "CANARY-5150" not in result
+
+
+def test_read_section_rejects_invalid_version(tmp_path):
+    from mcp_tools import read_laravel_doc_section_impl
+
+    result = read_laravel_doc_section_impl(tmp_path, "queues.md", "failed-jobs", "..")
+
+    assert "Invalid version" in result
+
+
+def test_read_section_costs_far_less_than_the_whole_file():
+    """The point of the exercise: a section instead of 34,000 tokens."""
+    from mcp_tools import read_laravel_doc_content_impl, read_laravel_doc_section_impl
+
+    whole = read_laravel_doc_content_impl(DOCS, "queues.md", VERSION)
+    section = read_laravel_doc_section_impl(
+        DOCS, "queues.md", "dealing-with-failed-jobs", VERSION
+    )
+
+    assert "Access denied" not in section
+    assert len(section) < len(whole) / 5, (
+        f"section {len(section)} vs whole {len(whole)} chars"
+    )

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -4,7 +4,8 @@ import pytest
 from pathlib import Path
 from unittest.mock import patch
 
-from laravel_mcp_companion import is_safe_path, get_version_from_path
+from laravel_mcp_companion import get_version_from_path
+from mcp_tools import is_safe_path
 import laravel_mcp_companion
 
 


### PR DESCRIPTION
Implements `docs/superpowers/specs/2026-07-31-chunked-bm25-retrieval-design.md`. Fixes the gap between what this project promises — the latest Laravel documentation at the ready when using LLMs — and what a developer actually experienced when they asked a question.

## The problem, measured

`search_laravel_docs` compiled the query with `re.escape` and ranked by raw match count:

| question | before |
|---|---|
| how do I validate a file upload | **0 results** |
| retry failed queue job | **0 results** |
| send email with attachment | **0 results** |
| rate limiting api routes | **0 results** |
| database transactions | ok |
| eloquent relationships | ok |
| queue | ok |

**Four of seven realistic questions returned nothing**, because a multi-word question is rarely a verbatim substring. Ranking was also anti-correlated with relevance — raw term frequency rewards long files, so `queues.md` (54 matches) ranked 13th of 24 for "queues", behind `images.md` (1 match).

When search failed, the only fallback was reading a whole file. `queues.md` is 34,048 tokens; 25% of files exceed 10,000.

## After

All seven return results, ranked, and the regression is **asserted as a test** rather than claimed here:

```
search_laravel_docs("how do I retry a failed queue job")
  13.x/queues.md  #dealing-with-failed-jobs  Dealing With Failed Jobs  26.29
    "Sometimes your queued jobs will fail... Laravel includes a convenient
     way to specify the maximum number of times a job should be attempted..."
```

End to end through a real MCP client:

```
search                ~416 tokens
read the section    ~2,797 tokens
TOTAL               ~3,213 tokens        (whole-file path: ~34,048)
                                          91% reduction
```

## Design decisions, each measured rather than assumed

**Chunk at `##`.** Finer granularity was sharper when it hit but regressed elsewhere: `##` got 4/4 correct top-1, while `###` and `<a name>` anchors each got 2/4 — short chunks give BM25 too few terms to discriminate. Anchors are better as *citation* targets than index units, which is exactly how they're used.

**Own the BM25 index (~70 lines).** fastmcp ships `_BM25Index`, generic enough to reuse, but it's a private underscore-prefixed class in a dependency that broke this project twice in one week, and it retains tokenized documents after build — most of the measured 26.5 MB per version. This keeps only term counts.

**Lazy in-memory indexes, no build-time artifact.** Chunking takes 6 ms and building 103 ms for a version; precomputing would add a build step, image weight and a staleness failure mode to save a tenth of a second. At ~13 MB each, **at most two indexes stay resident**, LRU-evicted, and the existing `clear_caches()` drops them on documentation update — invalidation needed no new machinery.

**Only symlinks get resolved during enumeration.** Resolving every file added a readlink walk per file per search; a plain direct child cannot escape its parent.

## Security

`search_laravel_docs_with_context` is removed, and its two security tests were **ported, not deleted**. That matters: there was no traversal test covering plain `search_laravel_docs`, so deleting them would have silently dropped coverage. The containment test matters more now than before — search returns *content* in snippets, not just match counts, so a leak there would be direct. All 99 security tests pass.

Chunking reads through `list_contained_markdown` and section reads validate via `resolve_contained_path`, so the containment and TOCTOU hardening carries over rather than being reimplemented.

## Two bugs my own tests caught

**Anchors were off by one.** Laravel puts `<a name="...">` on the line *before* its heading, so after splitting they attach to the wrong section. The unit test caught it; the real-document check made the cause obvious (`introduction` had landed on heading "Queues"). The root cause was subtler still — my anchor pattern stopped at the opening tag's `>`, leaving `</a>` behind, so "is anything after this anchor?" was always true.

**Snippets collapsed to the heading.** Laravel formats paragraphs as single long lines, so the nearest newline is often the one right after the heading, and the line-boundary trim snapped back to it — returning `## Dealing With Failed Jobs...` and nothing else. Trimming now only applies when it leaves a usable snippet.

## Test plan

- [x] **654 tests pass** (was 608); ruff and mypy clean across 40 files; coverage 67.48%
- [x] 46 new tests, each written and watched to fail first
- [x] Retrieval regression asserted: 3/7 → **7/7**
- [x] Ranking asserted: `queues.md` is now the top hit for "queue jobs and workers"
- [x] Token budget asserted, so search output cannot silently balloon back
- [x] Exact-symbol lookup (`queue:retry`) preserved via substring fallback
- [x] All 99 traversal and containment tests still pass
- [x] MCP Inspector smoke test green
- [x] Verified end to end through a real `fastmcp.Client`

## Follow-ups, deliberately not bundled

The freshness metric reporting fetch-age instead of content-age (it currently tells the assistant that five of eight *perfectly current* versions are stale), `read_laravel_doc_content` not being pinned in the search transform, and the four unused `TOOL_DESCRIPTIONS` entries. Each is its own change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documentation search now returns ranked sections with relevant snippets and anchors.
  * Added focused section reading by heading or anchor.
  * Added configurable result limits and support for version and external-service searches.

* **Bug Fixes**
  * Improved path containment and symlink protections for documentation access.
  * Added literal matching fallback for symbol and substring searches.

* **Breaking Changes**
  * Removed the legacy context-search operation.
  * Updated search results to use the new structured section format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->