### PR TITLE
Report when Laravel changed the documentation, not when we fetched it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,12 +26,35 @@ docs-only commit and contains no code change.
   nothing at all; ranking by raw match count also placed `queues.md` 13th of 24
   for "queues", behind a file with a single match. An exact-symbol query such as
   `queue:retry` still works, via a substring fallback.
+- `update_laravel_docs` takes `version` rather than `version_param`. Every other
+  tool takes `version`, so an assistant following the server's own advice
+  guessed it and received a hard error; the name being broken is one that never
+  worked.
 
 ### Added
 - `read_laravel_doc_section` reads one section by anchor or heading, as returned
   by search. Answering "how do I retry a failed queue job" end to end now costs
   about 3,200 tokens against roughly 34,000 for the whole-file path — `queues.md`
   alone is 34,048 tokens, and a quarter of the files exceed 10,000.
+- The server now reports the date Laravel last changed the documentation it
+  serves. MCP server instructions carry that date for the version being served,
+  so an assistant asked about a feature added after it says so rather than
+  answering as if the documentation covered it. `laravel_docs_info` reports
+  `documentation_date` per version, and `documentation_current_to` /
+  `copy_age_days` for the copy as a whole.
+
+  This reads `commit_date` rather than the time of the last fetch. The two
+  diverge for a branch Laravel no longer changes: the fetch time recedes
+  forever, so five of eight shipped versions were being called stale while
+  byte-identical to upstream, with a warning no tool could clear. The staleness
+  warning now fires only when *no* version has changed in over 30 days, which
+  means the copy itself is behind rather than upstream being quiet, and it
+  advises pulling a newer image instead of running a tool that cannot help.
+- Tests asserting the project version matches the newest release tag, and stays
+  consistent across `pyproject.toml`, `ROADMAP.md`, and `README.md`. The tag
+  comparison is the one that matters: during the drift that motivated these
+  guards, all three files agreed with each other and only the tags disagreed.
+- Tests asserting pytest and coverage are each configured in exactly one place.
 
 ### Changed
 - Documentation syncs are tagged `docs-YYYY-MM-DD` instead of incrementing the
@@ -41,7 +64,6 @@ docs-only commit and contains no code change.
   enabled in one place, so a bare `pytest` and CI report the same figure. The
   previous CI invocation also measured the test suite, inflating the reported
   number well above actual product coverage.
-
 - CI installs Python 3.12 rather than inheriting the runner image's 3.10. The
   project declares `requires-python = ">=3.12"`, so the only pipeline that runs
   had never validated a supported interpreter. The daily documentation job now
@@ -52,18 +74,6 @@ docs-only commit and contains no code change.
 - Removed a Harness cache configuration that failed on every run — it supplied
   no cache key, which the plugin requires for custom paths — leaving the test
   stage permanently degraded and masking the status of the steps that matter.
-
-### Added
-- The server now reports how old its documentation snapshot is. MCP server
-  instructions carry the snapshot date for the version being served, so an
-  assistant asked about a feature newer than that snapshot says so and offers to
-  refresh rather than answering from stale pages. `laravel_docs_info` reports
-  `snapshot_date` and `snapshot_age_days`, and flags snapshots older than 30 days.
-- Tests asserting the project version matches the newest release tag, and stays
-  consistent across `pyproject.toml`, `ROADMAP.md`, and `README.md`. The tag
-  comparison is the one that matters: during the drift that motivated these
-  guards, all three files agreed with each other and only the tags disagreed.
-- Tests asserting pytest and coverage are each configured in exactly one place.
 
 ## [0.10.0] - 2026-07-30
 

--- a/docs/superpowers/plans/2026-07-31-documentation-currency.md
+++ b/docs/superpowers/plans/2026-07-31-documentation-currency.md
@@ -1,0 +1,669 @@
+# Documentation Currency Reporting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Report the date Laravel last changed each documentation set, instead of the date this project last fetched it, so that end-of-life versions stop being reported as stale while identical to upstream.
+
+**Architecture:** Three functions in `mcp_tools.py` read `commit_date` rather than `sync_time`. Per-version staleness is removed outright; the staleness warning inverts to the *newest* change across versions, which is an offline proxy for how old this copy is. `update_laravel_docs` gains the `version` parameter name every other tool uses.
+
+**Tech Stack:** Python 3.12, pytest, FastMCP 3.4.5.
+
+## Global Constraints
+
+- Python >= 3.12. Run tests with `.venv/bin/python -m pytest`; ruff and mypy must stay clean.
+- Commit with `git lc`, never plain `git commit`.
+- `DOCS_STALE_AFTER_DAYS` keeps its name and value of 30.
+- No network calls. Offline operation is a headline feature; currency is reported from metadata already on disk.
+- Malformed, missing and future timestamps must keep behaving as they do now: report unknown, never raise, never clamp a future date to "today".
+- Do not add a metadata field. Writing one on every cron run would produce a daily commit, tag and image build for metadata-only churn.
+- The functions being replaced are consumed by `laravel_mcp_companion.py` at lines 55-58 (imports), 1168, 1567, 1578-1580, 1591 and 1609. Every one must be updated.
+
+---
+
+### Task 1: Read commit_date instead of sync_time
+
+**Files:**
+- Modify: `mcp_tools.py:318-395` (the freshness block)
+- Test: `tests/unit/test_docs_freshness.py`
+
+**Interfaces:**
+- Consumes: existing `get_laravel_docs_metadata`, `SUPPORTED_VERSIONS`.
+- Produces:
+  - `parse_timestamp(value: object) -> Optional[datetime]` (renamed from `parse_sync_time`)
+  - `get_documentation_date(docs_path: Path, version: Optional[str] = None) -> tuple[Optional[str], Optional[int]]` returning `("YYYY-MM-DD", age_days)`; for a specific version its own date, for no version the **newest** across versions
+  - `describe_documentation_date(docs_path: Path, version: Optional[str] = None) -> str` returning a bare date or `"unknown"`
+  - `copy_is_stale(docs_path: Path) -> bool` — no version argument
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# replace the body of tests/unit/test_docs_freshness.py
+"""Currency reporting reflects when Laravel changed its documentation.
+
+The previous implementation measured when this project last fetched a change.
+For a branch that no longer changes that recedes forever, so five of eight
+shipped versions were reported stale while byte-identical to upstream.
+"""
+
+import json
+import time
+
+import pytest
+
+from mcp_tools import (
+    DOCS_STALE_AFTER_DAYS,
+    copy_is_stale,
+    describe_documentation_date,
+    get_documentation_date,
+    parse_timestamp,
+)
+
+
+def write_metadata(docs_path, version, changed_days_ago, fetched_days_ago=None):
+    """Write metadata for a version, separating change date from fetch date."""
+    if fetched_days_ago is None:
+        fetched_days_ago = changed_days_ago
+    metadata_dir = docs_path / version / ".metadata"
+    metadata_dir.mkdir(parents=True, exist_ok=True)
+    fmt = "%Y-%m-%dT%H:%M:%SZ"
+    (metadata_dir / "sync_info.json").write_text(json.dumps({
+        "version": version,
+        "sync_time": time.strftime(fmt, time.gmtime(time.time() - fetched_days_ago * 86400)),
+        "commit_date": time.strftime(fmt, time.gmtime(time.time() - changed_days_ago * 86400)),
+        "commit_sha": "abc1234",
+    }))
+
+
+class TestDocumentationDate:
+    def test_reports_when_the_documentation_changed_not_when_it_was_fetched(self, tmp_path):
+        """The distinction the whole change rests on."""
+        write_metadata(tmp_path, "13.x", changed_days_ago=400, fetched_days_ago=1)
+
+        _, age = get_documentation_date(tmp_path, "13.x")
+
+        assert age == 400
+
+    @pytest.mark.parametrize("days", [0, 1, 30, 425])
+    def test_reports_age_in_days(self, tmp_path, days):
+        write_metadata(tmp_path, "13.x", changed_days_ago=days)
+        _, age = get_documentation_date(tmp_path, days and "13.x" or "13.x")
+        assert age == days
+
+    def test_across_versions_reports_the_newest(self, tmp_path):
+        """The newest change is a proxy for how old this copy is."""
+        write_metadata(tmp_path, "8.x", changed_days_ago=425)
+        write_metadata(tmp_path, "13.x", changed_days_ago=1)
+
+        _, age = get_documentation_date(tmp_path)
+
+        assert age == 1, "must report the newest, not the oldest"
+
+    def test_missing_metadata_is_not_an_error(self, tmp_path):
+        assert get_documentation_date(tmp_path) == (None, None)
+
+    @pytest.mark.parametrize("bad", ["garbage", "", None, 1753900000, {"a": 1}, ["x"]])
+    def test_malformed_commit_date_is_never_fatal(self, tmp_path, bad):
+        metadata_dir = tmp_path / "13.x" / ".metadata"
+        metadata_dir.mkdir(parents=True, exist_ok=True)
+        (metadata_dir / "sync_info.json").write_text(json.dumps({"commit_date": bad}))
+        assert get_documentation_date(tmp_path) == (None, None)
+
+    def test_future_dates_report_unknown(self, tmp_path):
+        """Clock skew must not be presented as freshness."""
+        write_metadata(tmp_path, "13.x", changed_days_ago=-5)
+        assert get_documentation_date(tmp_path) == (None, None)
+
+
+class TestStaleness:
+    def test_end_of_life_version_is_not_stale(self, tmp_path):
+        """The regression this change exists to fix.
+
+        8.x last changed 425 days ago and is byte-identical to upstream. It is
+        not stale; upstream simply stopped.
+        """
+        write_metadata(tmp_path, "8.x", changed_days_ago=425)
+        write_metadata(tmp_path, "13.x", changed_days_ago=1)
+
+        assert copy_is_stale(tmp_path) is False
+
+    def test_stale_when_every_version_is_old(self, tmp_path):
+        """A months-old image: even the active version stopped changing."""
+        write_metadata(tmp_path, "8.x", changed_days_ago=425)
+        write_metadata(tmp_path, "13.x", changed_days_ago=DOCS_STALE_AFTER_DAYS + 1)
+
+        assert copy_is_stale(tmp_path) is True
+
+    def test_not_stale_at_the_threshold(self, tmp_path):
+        write_metadata(tmp_path, "13.x", changed_days_ago=DOCS_STALE_AFTER_DAYS)
+        assert copy_is_stale(tmp_path) is False
+
+    def test_unknown_age_is_not_stale(self, tmp_path):
+        assert copy_is_stale(tmp_path) is False
+
+
+class TestDescription:
+    def test_returns_a_bare_date(self, tmp_path):
+        """No age phrasing: '425 days ago' reintroduces the alarm being removed."""
+        write_metadata(tmp_path, "8.x", changed_days_ago=425)
+
+        described = describe_documentation_date(tmp_path, "8.x")
+
+        assert "days ago" not in described
+        assert "today" not in described
+        assert described.count("-") == 2, f"expected a bare date, got {described!r}"
+
+    def test_unknown_when_no_metadata(self, tmp_path):
+        assert "unknown" in describe_documentation_date(tmp_path, "13.x")
+
+
+class TestParseTimestamp:
+    @pytest.mark.parametrize("value", [None, "", "unknown", "not-a-date", 17539, {}, []])
+    def test_unparseable_values_return_none(self, value):
+        assert parse_timestamp(value) is None
+
+    def test_zulu_suffix_is_understood(self):
+        parsed = parse_timestamp("2026-07-30T12:00:00Z")
+        assert parsed is not None and parsed.year == 2026
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_docs_freshness.py -q --no-cov -p no:cacheprovider`
+Expected: FAIL, `ImportError: cannot import name 'copy_is_stale'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace `mcp_tools.py` lines 318-395 (from `def parse_sync_time` through the end of `docs_are_stale`) with:
+
+```python
+def parse_timestamp(value: object) -> Optional[datetime]:
+    """Parse a metadata timestamp into an aware UTC datetime, or None.
+
+    Total by design. Metadata lives in a mutable, network-populated directory
+    that users can mount over, and this runs during server construction -- a
+    malformed value must degrade to "unknown", never raise.
+    """
+    if not isinstance(value, str) or not value or value == "unknown":
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def get_documentation_date(
+    docs_path: Path, version: Optional[str] = None
+) -> tuple[Optional[str], Optional[int]]:
+    """Return (date, age_in_days) for when Laravel last changed the documentation.
+
+    Reads `commit_date`, not `sync_time`. `sync_time` records when this project
+    last fetched a change, which for a branch that no longer changes recedes
+    forever -- reporting an end-of-life version as increasingly stale while it
+    is byte-identical to upstream.
+
+    For a specific version, that version's date. Across versions, the *newest*:
+    13.x changes near-daily, so the most recent change is a proxy for how old
+    this copy is, which is the only part a user can act on.
+
+    Returns (None, None) when no metadata is readable, or when the date is in
+    the future -- clock skew we cannot interpret and must not present as fresh.
+    """
+    base = Path(docs_path)
+    versions = [version] if version is not None else SUPPORTED_VERSIONS
+    newest: Optional[datetime] = None
+
+    for candidate in versions:
+        metadata = get_laravel_docs_metadata(base, candidate)
+        if not isinstance(metadata, dict):
+            continue
+        changed = parse_timestamp(metadata.get("commit_date"))
+        if changed and (newest is None or changed > newest):
+            newest = changed
+
+    if newest is None:
+        return None, None
+
+    age = (datetime.now(timezone.utc) - newest).days
+    if age < 0:
+        logger.warning(f"Documentation commit_date is in the future: {newest.isoformat()}")
+        return None, None
+
+    return newest.strftime("%Y-%m-%d"), age
+
+
+def describe_documentation_date(docs_path: Path, version: Optional[str] = None) -> str:
+    """A bare date for the server instructions, or "unknown".
+
+    Deliberately carries no age phrasing. Rendering "425 days ago" would
+    reintroduce exactly the alarm this reporting exists to remove, even though
+    the number is factual.
+    """
+    date, _ = get_documentation_date(docs_path, version)
+    return date or "unknown (no documentation synced yet)"
+
+
+def copy_is_stale(docs_path: Path) -> bool:
+    """Whether this copy of the documentation is behind, judged offline.
+
+    Takes no version argument: a single version's date being old means upstream
+    stopped changing, which is neither a problem nor actionable. What is
+    actionable is a stale *image*, which shows up as every version being old --
+    including the one that normally changes daily.
+    """
+    _, age = get_documentation_date(docs_path)
+    return age is not None and age > DOCS_STALE_AFTER_DAYS
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_docs_freshness.py -q --no-cov -p no:cacheprovider`
+Expected: PASS
+
+- [ ] **Step 5: Verify against the real documentation tree**
+
+Run:
+
+```bash
+.venv/bin/python -c "
+from pathlib import Path
+from mcp_tools import get_documentation_date, copy_is_stale, SUPPORTED_VERSIONS
+for v in SUPPORTED_VERSIONS:
+    print(f'  {v:6} {get_documentation_date(Path(\"docs\"), v)}')
+print('  copy stale?', copy_is_stale(Path('docs')))
+"
+```
+
+Expected: each version reports its own upstream change date; 8.x and 9.x show 2025 dates with large ages; `copy stale? False`, because 13.x changed within the last day.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp_tools.py tests/unit/test_docs_freshness.py
+git lc -m "Report when documentation changed, not when it was fetched"
+```
+
+---
+
+### Task 2: Update the server instructions
+
+**Files:**
+- Modify: `laravel_mcp_companion.py:55-58` (imports) and `:1168` and the instruction text below it
+- Test: `tests/unit/test_docs_freshness.py`
+
+**Interfaces:**
+- Consumes: `describe_documentation_date` (Task 1).
+- Produces: no new API; `build_server_instructions` wording changes.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/unit/test_docs_freshness.py
+class TestServerInstructions:
+    def test_instructions_state_the_documentation_date(self, tmp_path):
+        from laravel_mcp_companion import build_server_instructions
+
+        write_metadata(tmp_path, "13.x", changed_days_ago=2)
+        instructions = build_server_instructions(tmp_path, "13.x")
+
+        assert "reflects Laravel's documentation as of" in instructions
+
+    def test_instructions_do_not_call_an_eol_version_stale(self, tmp_path):
+        """8.x is byte-identical to upstream; the model must not be told to refresh."""
+        from laravel_mcp_companion import build_server_instructions
+
+        write_metadata(tmp_path, "8.x", changed_days_ago=425)
+        instructions = build_server_instructions(tmp_path, "8.x")
+
+        assert "425 days ago" not in instructions
+        assert "stale" not in instructions.lower()
+
+    def test_instructions_report_the_served_version(self, tmp_path):
+        from laravel_mcp_companion import build_server_instructions
+
+        write_metadata(tmp_path, "8.x", changed_days_ago=425)
+        write_metadata(tmp_path, "13.x", changed_days_ago=0)
+
+        instructions = build_server_instructions(tmp_path, "8.x")
+        eight, _ = get_documentation_date(tmp_path, "8.x")
+
+        assert eight in instructions
+
+    def test_instructions_survive_missing_metadata(self, tmp_path):
+        from laravel_mcp_companion import build_server_instructions
+
+        assert "unknown" in build_server_instructions(tmp_path, "13.x")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_docs_freshness.py -q --no-cov -p no:cacheprovider -k Instructions`
+Expected: FAIL, the phrase "reflects Laravel's documentation as of" is absent.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `laravel_mcp_companion.py`, change the import block at lines 55-58 from
+`describe_docs_freshness, get_docs_snapshot_age, docs_are_stale, DOCS_STALE_AFTER_DAYS`
+to `describe_documentation_date, get_documentation_date, copy_is_stale, DOCS_STALE_AFTER_DAYS`.
+
+Change line 1168 from `freshness = describe_docs_freshness(...)` to:
+
+```python
+    documentation_date = describe_documentation_date(docs_path, runtime_version)
+```
+
+Replace the final paragraph of the instructions string with:
+
+```python
+    return f"""Laravel documentation for the whole ecosystem: core Laravel \
+{', '.join(SUPPORTED_VERSIONS)}, the first-party services (Forge, Vapor, Nova, \
+Envoyer), and community packages (Spatie, Livewire, Filament, Inertia).
+
+{workflow}
+
+Documentation answers default to Laravel {runtime_version}; pass `version` to target \
+another, or `all_versions` to search every one.
+
+This copy reflects Laravel's documentation as of {documentation_date}. If you are \
+asked about a feature that may have been added after that date, say so rather than \
+answering as if the documentation covered it. {info_tool} reports this date at any \
+time."""
+```
+
+Delete the `refresh` local variable and its three branch assignments: the
+instructions no longer tell the assistant to refresh, because refreshing cannot
+change a date set by upstream.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_docs_freshness.py -q --no-cov -p no:cacheprovider`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add laravel_mcp_companion.py tests/unit/test_docs_freshness.py
+git lc -m "Tell the assistant the documentation's date, not a refresh instruction"
+```
+
+---
+
+### Task 3: Update laravel_docs_info
+
+**Files:**
+- Modify: `laravel_mcp_companion.py:1567-1615` (the `laravel_docs_info` tool body)
+- Test: `tests/unit/test_docs_freshness.py`
+
+**Interfaces:**
+- Consumes: `get_documentation_date`, `copy_is_stale` (Task 1).
+- Produces: no new API; output fields change.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/unit/test_docs_freshness.py
+class TestDocsInfoTool:
+    @pytest.mark.asyncio
+    async def test_summary_does_not_warn_when_the_copy_is_current(self, tmp_path):
+        """The permanent-warning bug: 6.x can never get fresher."""
+        from fastmcp import Client
+
+        from laravel_mcp_companion import create_mcp_server
+
+        write_metadata(tmp_path, "6.x", changed_days_ago=425)
+        write_metadata(tmp_path, "13.x", changed_days_ago=1)
+
+        server = create_mcp_server("T", tmp_path, "13.x", transform_mode=None)
+        async with Client(server) as client:
+            result = await client.call_tool("laravel_docs_info", {})
+            text = result.content[0].text
+
+        assert "note" not in text, f"warned about a current copy: {text}"
+        assert "documentation_current_to" in text
+
+    @pytest.mark.asyncio
+    async def test_summary_warns_when_the_whole_copy_is_old(self, tmp_path):
+        from fastmcp import Client
+
+        from laravel_mcp_companion import create_mcp_server
+
+        write_metadata(tmp_path, "6.x", changed_days_ago=425)
+        write_metadata(tmp_path, "13.x", changed_days_ago=DOCS_STALE_AFTER_DAYS + 5)
+
+        server = create_mcp_server("T", tmp_path, "13.x", transform_mode=None)
+        async with Client(server) as client:
+            result = await client.call_tool("laravel_docs_info", {})
+            text = result.content[0].text
+
+        assert "note" in text
+        assert "pull" in text.lower(), "should advise pulling a newer image"
+        assert "update_laravel_docs" not in text, "that tool cannot fix a stale image"
+
+    @pytest.mark.asyncio
+    async def test_per_version_reports_a_date_and_never_warns(self, tmp_path):
+        from fastmcp import Client
+
+        from laravel_mcp_companion import create_mcp_server
+
+        write_metadata(tmp_path, "8.x", changed_days_ago=425)
+
+        server = create_mcp_server("T", tmp_path, "8.x", transform_mode=None)
+        async with Client(server) as client:
+            result = await client.call_tool("laravel_docs_info", {"version": "8.x"})
+            text = result.content[0].text
+
+        assert "documentation_date" in text
+        assert "note" not in text, "a version whose upstream stopped is not a problem"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_docs_freshness.py -q --no-cov -p no:cacheprovider -k DocsInfo`
+Expected: FAIL, `documentation_current_to` absent and a note present.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In the specific-version branch, replace the snapshot lines with:
+
+```python
+            documentation_date, _ = get_documentation_date(docs_path, version)
+            info: Dict[str, Any] = {
+                "version": version,
+                "documentation_date": documentation_date or "unknown",
+                "last_updated": metadata.get('sync_time', 'unknown'),
+                "commit_sha": metadata.get('commit_sha', 'unknown'),
+                "commit_date": metadata.get('commit_date', 'unknown'),
+                "commit_message": metadata.get('commit_message', 'unknown'),
+                "github_url": metadata.get('commit_url', 'unknown')
+            }
+            return toon_encode(info)
+```
+
+Delete the per-version staleness note entirely.
+
+In the all-versions branch, replace the per-row age lookup with a date, and the
+summary with:
+
+```python
+                if "version" in metadata:
+                    v_date, _ = get_documentation_date(docs_path, v)
+                    versions_data.append({
+                        "version": v,
+                        "documentation_date": v_date or "unknown",
+                        "last_updated": metadata.get('sync_time', 'unknown'),
+                        "commit": metadata.get('commit_sha', 'unknown')[:7] if metadata.get('commit_sha') else 'unknown',
+                        "available": True
+                    })
+```
+
+```python
+            current_to, copy_age = get_documentation_date(docs_path)
+            summary: Dict[str, Any] = {
+                "documentation_current_to": current_to or "unknown",
+                "copy_age_days": copy_age if copy_age is not None else "unknown",
+                "default_version": runtime_version,
+                "versions": versions_data
+            }
+            if copy_is_stale(docs_path):
+                summary["note"] = (
+                    f"No version has changed in over {DOCS_STALE_AFTER_DAYS} days, which "
+                    "suggests this copy is behind. Pull a newer image to get current "
+                    "documentation."
+                )
+            return toon_encode(summary)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_docs_freshness.py -q --no-cov -p no:cacheprovider`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add laravel_mcp_companion.py tests/unit/test_docs_freshness.py
+git lc -m "Report documentation dates and warn only on a stale copy"
+```
+
+---
+
+### Task 4: Rename version_param to version
+
+**Files:**
+- Modify: `laravel_mcp_companion.py:1495-1510`
+- Test: `tests/unit/test_docs_freshness.py`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `update_laravel_docs(version: Optional[str] = None, force: bool = False)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/unit/test_docs_freshness.py
+class TestUpdateToolParameterName:
+    @pytest.mark.asyncio
+    async def test_accepts_the_parameter_name_every_other_tool_uses(self, tmp_path):
+        """An assistant told to refresh guesses `version`; it used to hard-error."""
+        from fastmcp import Client
+
+        from laravel_mcp_companion import create_mcp_server
+
+        write_metadata(tmp_path, "13.x", changed_days_ago=1)
+        server = create_mcp_server("T", tmp_path, "13.x", transform_mode=None)
+
+        async with Client(server) as client:
+            tools = {t.name: t for t in await client.list_tools()}
+            schema = tools["update_laravel_docs"].inputSchema
+
+        assert "version" in schema["properties"]
+        assert "version_param" not in schema["properties"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_docs_freshness.py -q --no-cov -p no:cacheprovider -k ParameterName`
+Expected: FAIL, `assert 'version' in {...'version_param'...}`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `laravel_mcp_companion.py`, rename the parameter and its three uses:
+
+```python
+    def update_laravel_docs(version: Optional[str] = None, force: bool = False) -> str:
+        """Update Laravel documentation from the official repository.
+
+        Args:
+            version: Laravel version branch (e.g., "12.x")
+            force: Force update even if already up to date
+        """
+        logger.debug(f"update_laravel_docs called (version: {version}, force: {force})")
+
+        doc_version = version or runtime_version
+
+        version_error = validate_version_arg(version)
+        if version_error:
+            return version_error
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_docs_freshness.py -q --no-cov -p no:cacheprovider`
+Expected: PASS
+
+- [ ] **Step 5: Run the whole suite, ruff and mypy**
+
+```bash
+.venv/bin/python -m pytest -q --no-cov -p no:cacheprovider
+.venv/bin/ruff check .
+.venv/bin/mypy --ignore-missing-imports .
+```
+
+Existing tests referencing `version_param`, `docs_are_stale`,
+`get_docs_snapshot_age`, `describe_docs_freshness` or `parse_sync_time` must be
+updated to the new names. Update assertions to the new behaviour rather than
+weakening them — in particular, a test asserting that an old version is stale is
+now asserting the bug and should be inverted.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add laravel_mcp_companion.py tests/
+git lc -m "Accept `version` on update_laravel_docs"
+```
+
+---
+
+### Task 5: Documentation and changelog
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Update the CHANGELOG**
+
+Add under `## [Unreleased]`, in the existing `### Breaking` and `### Fixed` sections:
+
+```markdown
+- `update_laravel_docs` takes `version` rather than `version_param`. Every other
+  tool takes `version`, so an assistant following the server's own advice
+  guessed it and received a hard error.
+- `laravel_docs_info` reports `documentation_date` per version and
+  `documentation_current_to` / `copy_age_days` in the summary, replacing the
+  snapshot-age fields.
+```
+
+```markdown
+- Documentation currency is reported from the date Laravel last changed each
+  version, not the date this project last fetched it. The two diverge for a
+  branch that no longer changes, so five of eight shipped versions were being
+  reported as stale while byte-identical to upstream, with a warning that no
+  tool could clear. The staleness warning now fires only when no version has
+  changed recently, which indicates a stale image rather than an end-of-life
+  branch.
+```
+
+- [ ] **Step 2: Verify the version guard still passes**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_version_consistency.py -q --no-cov -p no:cacheprovider`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md
+git lc -m "Record the documentation currency change"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** `commit_date` as the signal — Task 1 (`get_documentation_date`). Bare date, no age phrasing — Task 1 (`describe_documentation_date`) and its test. Warning inverted to the newest change — Task 1 (`copy_is_stale`) and Task 3's summary. No per-version staleness — Task 1 removes the parameter, Task 3 deletes the note, and both are asserted. `version_param` rename — Task 4. Offline preserved — no task adds a network call. Malformed, missing and future timestamps — Task 1's parametrized tests. Field renames — Task 3. Constant name and value unchanged — Global Constraints.
+
+**Placeholders.** None; every code step carries real code and every test step real assertions.
+
+**Type consistency.** `get_documentation_date` returns `tuple[Optional[str], Optional[int]]` in Task 1 and is unpacked as `(date, age)` in Tasks 1, 2 and 3. `copy_is_stale(docs_path) -> bool` is defined in Task 1 with no version argument and called that way in Task 3. `describe_documentation_date` returns `str` and is interpolated into a string in Task 2. `parse_timestamp` is defined in Task 1 and referenced only by its own tests.
+
+**One gap found and closed:** Task 1's step 3 replaces a specific line range, so it must delete `docs_are_stale`'s `age_days` parameter, which Task 3's old call site passed. Task 3 now rewrites that call as `copy_is_stale(docs_path)` with no arguments, and the Global Constraints list every consumer line so none is missed.

--- a/docs/superpowers/specs/2026-07-31-documentation-currency-design.md
+++ b/docs/superpowers/specs/2026-07-31-documentation-currency-design.md
@@ -1,0 +1,171 @@
+# Documentation Currency Reporting — Design
+
+**Date:** 2026-07-31
+**Status:** Approved, not yet implemented
+
+## Problem
+
+The freshness reporting added in v0.10.0 measures the wrong thing, and the
+result is worse than reporting nothing.
+
+`sync_time` records when this project last *fetched* a change, not when the
+documentation last *changed*. `DocsUpdater.update()` returns early when the
+upstream commit SHA matches (`docs_updater.py:1704`) and therefore never
+rewrites the metadata, so `sync_time` is frozen at the last content change. For
+a branch that no longer changes, it recedes indefinitely.
+
+Every one of the eight shipped versions matches `laravel/docs` branch HEAD
+exactly. Verified against the GitHub API — for example 9.x, local
+`177c095cc802` against upstream `177c095cc802`. Despite that:
+
+- **Five of eight versions are reported as stale.** The server tells the
+  assistant that 6.x, 8.x, 9.x, 10.x and 11.x are "more than 30 days old" and
+  should be refreshed, while they are byte-identical to upstream.
+- **The warning cannot be cleared.** Calling `update_laravel_docs` returns
+  "Documentation is already up to date" and leaves `sync_time` untouched, so the
+  warning persists. An assistant that follows the server's own instruction loops.
+- **The recommended tool rejects the obvious argument.** Every other tool takes
+  `version`; this one exposes `version_param`, a leaked internal name. Passing
+  `version='9.x'` raises `ToolError: Unexpected keyword argument`.
+- **`laravel_docs_info()` warns permanently.** With no version argument it
+  reports the *oldest* version's age — 425 days — and fires the staleness note
+  regardless of which version the user actually reads. Because 6.x can never get
+  fresher, that warning can never clear.
+
+The net effect is that the assistant hedges on correct documentation, is told to
+run a tool that cannot help, and guesses a parameter name the tool refuses.
+
+## Goals
+
+1. Report something true about every version, including end-of-life ones.
+2. Give the assistant what it actually needs: whether the documentation could
+   predate the feature being asked about.
+3. Warn only about a problem the user can act on.
+4. Preserve offline operation.
+
+## Non-goals
+
+Verifying against upstream at runtime, and any change to the Dockerfile layer
+ordering or `--pull=always` economics. Also out of scope: pinning
+`read_laravel_doc_content` in the search transform.
+
+## Design
+
+### Report the documentation's own date
+
+Use `commit_date`, already present in every version's metadata. It is the date
+Laravel last changed that documentation upstream.
+
+> The Laravel 8.x documentation reflects Laravel's documentation as of
+> 2025-04-01.
+
+That is true, needs no network, adds no metadata field, and reads correctly for
+an end-of-life branch. It also answers the question the assistant actually has:
+anything Laravel added after that date is not in this corpus, so the model can
+decide for itself whether to caveat an answer.
+
+Real values:
+
+| version | upstream last changed | fetched |
+|---|---|---|
+| 13.x | 2026-07-30 | 2026-07-31 |
+| 12.x | 2026-07-27 | 2026-07-28 |
+| 11.x | 2026-04-20 | 2026-04-21 |
+| 8.x | 2025-04-01 | 2025-06-01 |
+
+### Warn on the newest change, not the oldest
+
+The one thing `commit_date` alone cannot tell you is whether *this copy* is
+behind — a user running a six-month-old image sees dates that are accurate for
+what they have while newer documentation exists.
+
+That is detectable offline. 13.x changes near-daily, so the **newest**
+`commit_date` across all versions is a proxy for when this copy was built. If
+the most recently changed version last changed months ago, the copy is months
+old.
+
+So the warning inverts: it fires when the newest change across all versions is
+older than `DOCS_STALE_AFTER_DAYS` (30), meaning "this copy is behind, pull a newer
+image." It no longer fires because an end-of-life branch stopped changing.
+
+Measured today: newest change across all versions is 2026-07-30, zero days ago.
+
+### Rename `version_param` to `version`
+
+`update_laravel_docs(version_param=...)` is the only tool not taking `version`.
+An assistant told to refresh documentation guesses `version` and receives a hard
+`ToolError`. This is a breaking change to a tool signature, accepted because the
+current name is a leaked internal and the tool is unusable as named.
+
+## Data flow
+
+Internals keep their shape so callers change minimally:
+
+```
+get_documentation_date(docs_path, version) -> (date_str | None, age_days | None)
+  reads commit_date; replaces get_docs_snapshot_age
+
+describe_documentation_date(docs_path, version) -> str
+  "2026-07-30", or "unknown" -- a bare date, no age phrasing
+
+copy_is_stale(docs_path) -> bool
+  newest commit_date across versions older than DOCS_STALE_AFTER_DAYS
+  takes no version: per-version staleness is not a meaningful question
+```
+
+**No per-version staleness.** A version's `commit_date` being old means upstream
+stopped changing, which is not a problem and not actionable. `docs_are_stale` is
+replaced by `copy_is_stale`, which takes no version argument, so there is no way
+to ask the meaningless question.
+
+**No age phrasing in the served-version report.** `describe_documentation_date`
+returns the bare date. Rendering "425 days ago" would reintroduce exactly the
+alarm this change removes, even though the number is factual.
+`DOCS_STALE_AFTER_DAYS` keeps its name and value of 30.
+
+`laravel_docs_info` field changes:
+
+- per version: `age_days` becomes `documentation_date`. No per-version age
+  number, for the reason above.
+- summary: `oldest_snapshot_date` / `oldest_snapshot_age_days` become
+  `documentation_current_to` (newest `commit_date`) and `copy_age_days`
+- the per-version branch emits no staleness note at all
+- the summary note fires on copy age and says to pull a newer image, not to run
+  `update_laravel_docs`, which cannot help
+
+## Error handling
+
+Unchanged from the existing implementation, which already handles these and
+applies equally to `commit_date`: malformed or non-string timestamps report
+unknown rather than raising, a future timestamp reports unknown and logs a
+warning rather than being clamped to "today", and a missing metadata file is not
+an error.
+
+## Testing
+
+Written failing-first.
+
+- **The regression that matters:** a version whose `commit_date` is old but which
+  matches upstream is *not* reported as stale. Uses 9.x-shaped metadata — old
+  `commit_date`, old `sync_time` — and asserts no staleness warning.
+- `laravel_docs_info()` with no version does not warn when the newest version is
+  current, even while older versions have old dates. This is the permanent-warning
+  bug and it must be pinned.
+- The warning *does* fire when every version's `commit_date` is old, which is the
+  stale-image case it now exists to catch.
+- Instructions quote the served version's documentation date, not another
+  version's.
+- `update_laravel_docs` accepts `version=`; the old `version_param=` is gone.
+- Malformed, missing and future `commit_date` values behave as the existing
+  freshness tests already require.
+
+## Risks
+
+**A stale image is only inferred, not measured.** The proxy assumes 13.x keeps
+changing. If Laravel froze all branches simultaneously the warning would go
+quiet — an acceptable failure mode, since in that case there would be nothing to
+pull.
+
+**Another breaking change to a tool signature.** Mitigated: the argument being
+renamed cannot currently be passed successfully by name, so the surface being
+broken is one that does not work.

--- a/laravel_mcp_companion.py
+++ b/laravel_mcp_companion.py
@@ -52,9 +52,9 @@ from mcp_tools import (
     validate_version as validate_version_arg,
     count_matches,
     clear_caches as clear_mcp_tools_caches,
-    describe_docs_freshness,
-    get_docs_snapshot_age,
-    docs_are_stale,
+    describe_documentation_date,
+    get_documentation_date,
+    copy_is_stale,
     DOCS_STALE_AFTER_DAYS
 )
 
@@ -1151,44 +1151,38 @@ def build_server_instructions(
 ) -> str:
     """Compose the instructions an MCP client injects into the model's context.
 
-    This is where the assistant learns how old the bundled documentation is.
-    Without it, a stale snapshot produces confidently wrong answers about recent
-    Laravel features, because nothing in the tool output says how old the corpus
-    is and the user has no reason to suspect it.
+    This is where the assistant learns what date the bundled documentation
+    describes. Without it, the model answers questions about features newer than
+    the corpus without knowing the corpus could not contain them, and the user
+    has no reason to suspect it.
 
-    The freshness reported is that of `runtime_version`, the version this server
+    The date reported is that of `runtime_version`, the version this server
     actually answers from. Reporting the newest version present would describe a
-    corpus the user is not reading -- an older pinned version can be months
+    corpus the user is not reading -- an older pinned version can be a year
     behind while another sits at today's date.
 
     The described workflow follows `transform_mode`, because the search and code
     transforms replace the individual tools with a small synthetic surface.
     Naming hidden tools would invite calls the client cannot route.
     """
-    freshness = describe_docs_freshness(docs_path, runtime_version)
+    documentation_date = describe_documentation_date(docs_path, runtime_version)
 
     if transform_mode == "search":
         workflow = """Tools are exposed through a search interface rather than listed \
 individually. Call search_tools with a natural-language description to find the right \
 tool, then invoke it through call_tool with its name and arguments. \
 search_laravel_docs is also available directly."""
-        refresh = ('call_tool with "update_laravel_docs" (or '
-                   '"update_external_laravel_docs" for the first-party services and '
-                   'package documentation)')
         info_tool = 'call_tool with "laravel_docs_info"'
     elif transform_mode == "code":
         workflow = """Tools are exposed through Code Mode. Use tags and search to \
 discover them, get_schema for their parameters, and execute to run Python that calls \
 them."""
-        refresh = "the update_laravel_docs tool (or update_external_laravel_docs)"
         info_tool = "the laravel_docs_info tool"
     else:
         workflow = """Typical flow: search_laravel_docs to locate relevant files, then \
 read_laravel_doc_content for the full text. For a natural-language request such as \
 "I need to upload files", find_laravel_docs_for_need maps it to the right pages. \
 get_laravel_package_recommendations suggests packages for a described use case."""
-        refresh = ("update_laravel_docs (or update_external_laravel_docs for the "
-                   "first-party services and package documentation)")
         info_tool = "laravel_docs_info"
 
     return f"""Laravel documentation for the whole ecosystem: core Laravel \
@@ -1200,10 +1194,10 @@ Envoyer), and community packages (Spatie, Livewire, Filament, Inertia).
 Documentation answers default to Laravel {runtime_version}; pass `version` to target \
 another, or `all_versions` to search every one.
 
-The Laravel {runtime_version} documentation is a local snapshot, last synced \
-{freshness}. If you are asked about a feature that may have landed after that date, \
-say so rather than answering from the snapshot, and offer to refresh it first using \
-{refresh}. {info_tool} reports the current snapshot date at any time."""
+This copy reflects Laravel's documentation as of {documentation_date}. If you are \
+asked about a feature that may have been added after that date, say so rather than \
+answering as if the documentation covered it. {info_tool} reports this date at any \
+time."""
 
 
 def validate_version(version: str) -> bool:
@@ -1492,20 +1486,20 @@ def configure_mcp_server(mcp: FastMCP, docs_path: Path, runtime_version: str, mu
         tags={"docs", "write"},
         timeout=120.0
     )
-    def update_laravel_docs(version_param: Optional[str] = None, force: bool = False) -> str:
+    def update_laravel_docs(version: Optional[str] = None, force: bool = False) -> str:
         """
         Update Laravel documentation from official GitHub repository.
-        
+
         Args:
-            version_param: Laravel version branch (e.g., "12.x")
+            version: Laravel version branch (e.g., "12.x")
             force: Force update even if already up to date
         """
-        logger.debug(f"update_laravel_docs function called (version: {version_param}, force: {force})")
+        logger.debug(f"update_laravel_docs function called (version: {version}, force: {force})")
 
         # Use provided version or default to the one specified at startup
-        doc_version = version_param or runtime_version
+        doc_version = version or runtime_version
 
-        version_error = validate_version_arg(version_param)
+        version_error = validate_version_arg(version)
         if version_error:
             return version_error
 
@@ -1564,22 +1558,18 @@ def configure_mcp_server(mcp: FastMCP, docs_path: Path, runtime_version: str, mu
                     {"suggestion": "Use update_laravel_docs() to fetch documentation"}
                 )
 
-            snapshot, age_days = get_docs_snapshot_age(docs_path, version)
+            # No staleness note here. An old date means Laravel stopped changing
+            # this branch, which is neither a problem nor something a tool can fix.
+            documentation_date, _ = get_documentation_date(docs_path, version)
             info: Dict[str, Any] = {
                 "version": version,
+                "documentation_date": documentation_date or "unknown",
                 "last_updated": metadata.get('sync_time', 'unknown'),
-                "snapshot_date": snapshot or "unknown",
-                "snapshot_age_days": age_days if age_days is not None else "unknown",
                 "commit_sha": metadata.get('commit_sha', 'unknown'),
                 "commit_date": metadata.get('commit_date', 'unknown'),
                 "commit_message": metadata.get('commit_message', 'unknown'),
                 "github_url": metadata.get('commit_url', 'unknown')
             }
-            if docs_are_stale(docs_path, version, age_days=age_days):
-                info["note"] = (
-                    f"This snapshot is more than {DOCS_STALE_AFTER_DAYS} days old. "
-                    "Run update_laravel_docs() before relying on it for recent features."
-                )
             return toon_encode(info)
         else:
             # Show info for all available versions
@@ -1588,13 +1578,12 @@ def configure_mcp_server(mcp: FastMCP, docs_path: Path, runtime_version: str, mu
             for v in SUPPORTED_VERSIONS:
                 metadata = get_laravel_docs_metadata(docs_path, v)
                 if "version" in metadata:
-                    _, v_age = get_docs_snapshot_age(docs_path, v)
+                    v_date, _ = get_documentation_date(docs_path, v)
                     versions_data.append({
                         "version": v,
+                        "documentation_date": v_date or "unknown",
                         "last_updated": metadata.get('sync_time', 'unknown'),
-                        "age_days": v_age if v_age is not None else "unknown",
                         "commit": metadata.get('commit_sha', 'unknown')[:7] if metadata.get('commit_sha') else 'unknown',
-                        "commit_date": metadata.get('commit_date', 'unknown'),
                         "available": True
                     })
                 else:
@@ -1603,21 +1592,23 @@ def configure_mcp_server(mcp: FastMCP, docs_path: Path, runtime_version: str, mu
                         "available": False
                     })
 
-            # Across versions this reports the OLDEST snapshot. The per-version
-            # rows carry the detail; a headline quoting the freshest version
-            # would imply the whole corpus is current when most of it is not.
-            oldest_date, oldest_age = get_docs_snapshot_age(docs_path)
+            # The headline is the NEWEST change across versions. Laravel changes
+            # its current branch most days, so that date is a proxy for how old
+            # this copy is -- the only part the user can act on. Quoting the
+            # oldest instead reports an end-of-life branch that upstream simply
+            # stopped touching, and warns forever about nothing.
+            current_to, copy_age = get_documentation_date(docs_path)
             summary: Dict[str, Any] = {
-                "oldest_snapshot_date": oldest_date or "unknown",
-                "oldest_snapshot_age_days": oldest_age if oldest_age is not None else "unknown",
+                "documentation_current_to": current_to or "unknown",
+                "copy_age_days": copy_age if copy_age is not None else "unknown",
                 "default_version": runtime_version,
                 "versions": versions_data
             }
-            if docs_are_stale(docs_path, age_days=oldest_age):
+            if copy_is_stale(docs_path):
                 summary["note"] = (
-                    f"At least one version's documentation is more than {DOCS_STALE_AFTER_DAYS} "
-                    "days old. Check the per-version rows and run update_laravel_docs() for any "
-                    "version you intend to rely on."
+                    f"No version has changed in over {DOCS_STALE_AFTER_DAYS} days, which "
+                    "suggests this copy is behind. Pull a newer image to get current "
+                    "documentation."
                 )
             return toon_encode(summary)
     

--- a/mcp_tools.py
+++ b/mcp_tools.py
@@ -309,14 +309,13 @@ def validate_subdirectory(base_dir: Path, name: str) -> bool:
         return False
 
 
-# Documentation is shipped as a snapshot, so it ages. Past this many days we
-# start saying so out loud rather than letting the assistant answer from a stale
-# corpus without realising it.
+# Laravel changes 13.x most days. When nothing has changed anywhere in this many
+# days, the copy itself is behind rather than upstream being quiet.
 DOCS_STALE_AFTER_DAYS = 30
 
 
-def parse_sync_time(value: object) -> Optional[datetime]:
-    """Parse a metadata sync_time into an aware UTC datetime, or None.
+def parse_timestamp(value: object) -> Optional[datetime]:
+    """Parse a metadata timestamp into an aware UTC datetime, or None.
 
     Total by design. Metadata lives in a mutable, network-populated directory
     that users can mount over, and this runs during server construction -- a
@@ -333,64 +332,69 @@ def parse_sync_time(value: object) -> Optional[datetime]:
     return parsed
 
 
-def get_docs_snapshot_age(docs_path: Path, version: Optional[str] = None) -> tuple[Optional[str], Optional[int]]:
-    """Return (sync_date, age_in_days) for the documentation snapshot.
+def get_documentation_date(
+    docs_path: Path, version: Optional[str] = None
+) -> tuple[Optional[str], Optional[int]]:
+    """Return (date, age_in_days) for when Laravel last changed the documentation.
 
-    For a specific version, reports that version. Across all versions, reports
-    the *oldest* one: the caller is asking whether the corpus can be trusted,
-    and the answer is governed by its stalest part. Reporting the newest would
-    describe a version the user may not be reading.
+    Reads `commit_date`, not `sync_time`. `sync_time` records when this project
+    last fetched a change, which for a branch that no longer changes recedes
+    forever -- reporting an end-of-life version as increasingly stale while it
+    is byte-identical to upstream.
 
-    Returns (None, None) when no metadata is readable, or when a timestamp is
-    in the future -- a clock skew we cannot interpret and must not present as
-    fresh.
+    For a specific version, that version's date. Across versions, the *newest*:
+    13.x changes near-daily, so the most recent change is a proxy for how old
+    this copy is, which is the only part a user can act on.
+
+    Returns (None, None) when no metadata is readable, or when the date is in
+    the future -- clock skew we cannot interpret and must not present as fresh.
     """
     # Callers reach this through server construction, where docs_path may still
     # be a plain string; joining one would raise rather than report "unknown".
     base = Path(docs_path)
     versions = [version] if version is not None else SUPPORTED_VERSIONS
-    oldest: Optional[datetime] = None
+    newest: Optional[datetime] = None
 
     for candidate in versions:
         metadata = get_laravel_docs_metadata(base, candidate)
         if not isinstance(metadata, dict):
             continue
-        synced = parse_sync_time(metadata.get("sync_time"))
-        if synced and (oldest is None or synced < oldest):
-            oldest = synced
+        changed = parse_timestamp(metadata.get("commit_date"))
+        if changed and (newest is None or changed > newest):
+            newest = changed
 
-    if oldest is None:
+    if newest is None:
         return None, None
 
-    age = (datetime.now(timezone.utc) - oldest).days
+    age = (datetime.now(timezone.utc) - newest).days
     if age < 0:
-        # Timestamp is in the future. Treating it as fresh would permanently
-        # disable the staleness warning under routine container clock skew.
-        logger.warning(f"Documentation sync_time is in the future: {oldest.isoformat()}")
+        logger.warning(f"Documentation commit_date is in the future: {newest.isoformat()}")
         return None, None
 
-    return oldest.strftime("%Y-%m-%d"), age
+    return newest.strftime("%Y-%m-%d"), age
 
 
-def describe_docs_freshness(docs_path: Path, version: Optional[str] = None) -> str:
-    """Human-readable snapshot age, for tool output and server instructions."""
-    snapshot, age = get_docs_snapshot_age(docs_path, version)
-    if snapshot is None:
-        return "unknown (no documentation synced yet)"
-    if age == 0:
-        return f"{snapshot} (today)"
-    return f"{snapshot} ({age} day{'s' if age != 1 else ''} ago)"
+def describe_documentation_date(docs_path: Path, version: Optional[str] = None) -> str:
+    """A bare date for the server instructions, or "unknown".
 
-
-def docs_are_stale(docs_path: Path, version: Optional[str] = None, age_days: Optional[int] = None) -> bool:
-    """Whether the snapshot is old enough to be worth mentioning.
-
-    Pass `age_days` when the caller has already computed it, to avoid re-reading
-    every version's metadata a second time.
+    Deliberately carries no age phrasing. Rendering "425 days ago" would
+    reintroduce exactly the alarm this reporting exists to remove, even though
+    the number is factual.
     """
-    if age_days is None:
-        _, age_days = get_docs_snapshot_age(docs_path, version)
-    return age_days is not None and age_days > DOCS_STALE_AFTER_DAYS
+    date, _ = get_documentation_date(docs_path, version)
+    return date or "unknown (no documentation synced yet)"
+
+
+def copy_is_stale(docs_path: Path) -> bool:
+    """Whether this copy of the documentation is behind, judged offline.
+
+    Takes no version argument: a single version's date being old means upstream
+    stopped changing, which is neither a problem nor actionable. What is
+    actionable is a stale *image*, which shows up as every version being old --
+    including the one that normally changes daily.
+    """
+    _, age = get_documentation_date(docs_path)
+    return age is not None and age > DOCS_STALE_AFTER_DAYS
 
 
 def get_laravel_docs_metadata(docs_path: Path, version: str) -> dict:

--- a/tests/unit/test_docs_freshness.py
+++ b/tests/unit/test_docs_freshness.py
@@ -1,9 +1,8 @@
-"""Tests for documentation freshness reporting.
+"""Currency reporting reflects when Laravel changed its documentation.
 
-Documentation ships as a snapshot, so it ages. The failure mode this guards
-against is silent: an assistant answering confidently about a recent Laravel
-feature from a corpus months out of date, with nothing in the output hinting
-that the corpus is old.
+The previous implementation measured when this project last fetched a change.
+For a branch that no longer changes that recedes forever, so five of eight
+shipped versions were reported stale while byte-identical to upstream.
 """
 
 import json
@@ -14,173 +13,174 @@ import pytest
 
 from mcp_tools import (
     DOCS_STALE_AFTER_DAYS,
-    describe_docs_freshness,
-    docs_are_stale,
-    get_docs_snapshot_age,
-    parse_sync_time,
+    copy_is_stale,
+    describe_documentation_date,
+    get_documentation_date,
+    parse_timestamp,
 )
 
 
-def write_snapshot(docs_path, days_old, version="12.x"):
-    """Create documentation metadata synced `days_old` days ago."""
+def write_metadata(docs_path, version, changed_days_ago, fetched_days_ago=None):
+    """Write metadata for a version, separating change date from fetch date."""
+    if fetched_days_ago is None:
+        fetched_days_ago = changed_days_ago
     metadata_dir = docs_path / version / ".metadata"
     metadata_dir.mkdir(parents=True, exist_ok=True)
-    synced = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() - days_old * 86400))
-    (metadata_dir / "sync_info.json").write_text(
-        json.dumps({"version": version, "sync_time": synced, "commit_sha": "abc1234"})
-    )
-    return synced
+    fmt = "%Y-%m-%dT%H:%M:%SZ"
+    (metadata_dir / "sync_info.json").write_text(json.dumps({
+        "version": version,
+        "sync_time": time.strftime(fmt, time.gmtime(time.time() - fetched_days_ago * 86400)),
+        "commit_date": time.strftime(fmt, time.gmtime(time.time() - changed_days_ago * 86400)),
+        "commit_sha": "abc1234",
+    }))
 
 
-class TestSnapshotAge:
-    @pytest.mark.parametrize("days", [0, 1, 5, 45, 400])
+class TestDocumentationDate:
+    def test_reports_when_the_documentation_changed_not_when_it_was_fetched(self, tmp_path):
+        """The distinction the whole change rests on."""
+        write_metadata(tmp_path, "13.x", changed_days_ago=400, fetched_days_ago=1)
+
+        _, age = get_documentation_date(tmp_path, "13.x")
+
+        assert age == 400
+
+    @pytest.mark.parametrize("days", [0, 1, 30, 425])
     def test_reports_age_in_days(self, tmp_path, days):
-        write_snapshot(tmp_path, days)
-        _, age = get_docs_snapshot_age(tmp_path)
+        write_metadata(tmp_path, "13.x", changed_days_ago=days)
+        _, age = get_documentation_date(tmp_path, "13.x")
         assert age == days
 
-    def test_reports_the_requested_version_not_the_freshest(self, tmp_path):
-        """A pinned old version must not inherit a newer version's freshness."""
-        write_snapshot(tmp_path, 101, version="11.x")
-        write_snapshot(tmp_path, 0, version="13.x")
+    def test_across_versions_reports_the_newest(self, tmp_path):
+        """The newest change is a proxy for how old this copy is."""
+        write_metadata(tmp_path, "8.x", changed_days_ago=425)
+        write_metadata(tmp_path, "13.x", changed_days_ago=1)
 
-        _, age = get_docs_snapshot_age(tmp_path, "11.x")
-        assert age == 101, "asking about 11.x must report 11.x"
+        _, age = get_documentation_date(tmp_path)
 
-    def test_aggregate_reports_the_oldest_version(self, tmp_path):
-        """Across versions, trustworthiness is governed by the stalest part."""
-        write_snapshot(tmp_path, 90, version="11.x")
-        write_snapshot(tmp_path, 3, version="12.x")
-
-        _, age = get_docs_snapshot_age(tmp_path)
-        assert age == 90, "the aggregate must not quote the freshest version"
+        assert age == 1, "must report the newest, not the oldest"
 
     def test_missing_metadata_is_not_an_error(self, tmp_path):
-        assert get_docs_snapshot_age(tmp_path) == (None, None)
+        assert get_documentation_date(tmp_path) == (None, None)
 
-    @pytest.mark.parametrize("sync_time", [
-        "garbage", "2026-13-45", "", None, 1753900000, 12.5, True,
-        {"nested": "object"}, ["list"],
-    ])
-    def test_malformed_sync_time_is_never_fatal(self, tmp_path, sync_time):
-        """Metadata is user-mountable and network-populated; it must never raise."""
-        metadata_dir = tmp_path / "12.x" / ".metadata"
+    @pytest.mark.parametrize("bad", ["garbage", "", None, 1753900000, {"a": 1}, ["x"]])
+    def test_malformed_commit_date_is_never_fatal(self, tmp_path, bad):
+        metadata_dir = tmp_path / "13.x" / ".metadata"
         metadata_dir.mkdir(parents=True, exist_ok=True)
-        (metadata_dir / "sync_info.json").write_text(json.dumps({"sync_time": sync_time}))
-        assert get_docs_snapshot_age(tmp_path) == (None, None)
+        (metadata_dir / "sync_info.json").write_text(json.dumps({"commit_date": bad}))
+        assert get_documentation_date(tmp_path) == (None, None)
 
     def test_metadata_that_is_not_an_object_is_not_fatal(self, tmp_path):
-        metadata_dir = tmp_path / "12.x" / ".metadata"
+        metadata_dir = tmp_path / "13.x" / ".metadata"
         metadata_dir.mkdir(parents=True)
         (metadata_dir / "sync_info.json").write_text('["not", "an", "object"]')
-        assert get_docs_snapshot_age(tmp_path) == (None, None)
+        assert get_documentation_date(tmp_path) == (None, None)
 
-    @pytest.mark.parametrize("days_ahead", [1, 2, 365])
-    def test_future_timestamps_report_unknown(self, tmp_path, days_ahead):
-        """Clock skew must not be presented as freshness.
-
-        Clamping a future age to zero would render the snapshot permanently
-        'today' and silently disable the staleness warning.
-        """
-        write_snapshot(tmp_path, -days_ahead)
-        assert get_docs_snapshot_age(tmp_path) == (None, None)
-        assert docs_are_stale(tmp_path) is False
-        assert "unknown" in describe_docs_freshness(tmp_path)
+    def test_future_dates_report_unknown(self, tmp_path):
+        """Clock skew must not be presented as freshness."""
+        write_metadata(tmp_path, "13.x", changed_days_ago=-5)
+        assert get_documentation_date(tmp_path) == (None, None)
+        assert copy_is_stale(tmp_path) is False
+        assert "unknown" in describe_documentation_date(tmp_path)
 
 
 class TestStaleness:
-    def test_fresh_docs_are_not_stale(self, tmp_path):
-        write_snapshot(tmp_path, 1)
-        assert docs_are_stale(tmp_path) is False
+    def test_end_of_life_version_is_not_stale(self, tmp_path):
+        """The regression this change exists to fix.
 
-    def test_docs_just_inside_the_threshold_are_not_stale(self, tmp_path):
-        write_snapshot(tmp_path, DOCS_STALE_AFTER_DAYS)
-        assert docs_are_stale(tmp_path) is False
+        8.x last changed 425 days ago and is byte-identical to upstream. It is
+        not stale; upstream simply stopped.
+        """
+        write_metadata(tmp_path, "8.x", changed_days_ago=425)
+        write_metadata(tmp_path, "13.x", changed_days_ago=1)
 
-    def test_docs_past_the_threshold_are_stale(self, tmp_path):
-        write_snapshot(tmp_path, DOCS_STALE_AFTER_DAYS + 1)
-        assert docs_are_stale(tmp_path) is True
+        assert copy_is_stale(tmp_path) is False
 
-    def test_unknown_age_is_not_reported_as_stale(self, tmp_path):
-        """Absent metadata must not produce a false staleness warning."""
-        assert docs_are_stale(tmp_path) is False
+    def test_stale_when_every_version_is_old(self, tmp_path):
+        """A months-old image: even the active version stopped changing."""
+        write_metadata(tmp_path, "8.x", changed_days_ago=425)
+        write_metadata(tmp_path, "13.x", changed_days_ago=DOCS_STALE_AFTER_DAYS + 1)
 
+        assert copy_is_stale(tmp_path) is True
 
-class TestFreshnessDescription:
-    def test_today_reads_naturally(self, tmp_path):
-        write_snapshot(tmp_path, 0)
-        assert "today" in describe_docs_freshness(tmp_path)
+    def test_not_stale_at_the_threshold(self, tmp_path):
+        write_metadata(tmp_path, "13.x", changed_days_ago=DOCS_STALE_AFTER_DAYS)
+        assert copy_is_stale(tmp_path) is False
 
-    def test_singular_day(self, tmp_path):
-        write_snapshot(tmp_path, 1)
-        assert "1 day ago" in describe_docs_freshness(tmp_path)
-
-    def test_plural_days(self, tmp_path):
-        write_snapshot(tmp_path, 12)
-        assert "12 days ago" in describe_docs_freshness(tmp_path)
-
-    def test_unknown_when_never_synced(self, tmp_path):
-        assert "unknown" in describe_docs_freshness(tmp_path)
+    def test_unknown_age_is_not_stale(self, tmp_path):
+        assert copy_is_stale(tmp_path) is False
 
 
-class TestParseSyncTime:
-    @pytest.mark.parametrize("value", [
-        None, "", "unknown", "not-a-date", "2026-13-45", 1753900000, 12.5, True, {}, [],
-    ])
+class TestDescription:
+    def test_returns_a_bare_date(self, tmp_path):
+        """No age phrasing: '425 days ago' reintroduces the alarm being removed."""
+        write_metadata(tmp_path, "8.x", changed_days_ago=425)
+
+        described = describe_documentation_date(tmp_path, "8.x")
+
+        assert "days ago" not in described
+        assert "today" not in described
+        assert described.count("-") == 2, f"expected a bare date, got {described!r}"
+
+    def test_unknown_when_no_metadata(self, tmp_path):
+        assert "unknown" in describe_documentation_date(tmp_path, "13.x")
+
+
+class TestParseTimestamp:
+    @pytest.mark.parametrize("value", [None, "", "unknown", "not-a-date", 17539, {}, []])
     def test_unparseable_values_return_none(self, value):
-        assert parse_sync_time(value) is None
+        assert parse_timestamp(value) is None
 
     def test_naive_timestamps_are_treated_as_utc(self):
-        parsed = parse_sync_time("2026-07-30T12:00:00")
+        parsed = parse_timestamp("2026-07-30T12:00:00")
         assert parsed is not None
         assert parsed.utcoffset() == timedelta(0), "a naive timestamp must be read as UTC"
 
     def test_zulu_suffix_is_understood(self):
-        parsed = parse_sync_time("2026-07-30T12:00:00Z")
+        parsed = parse_timestamp("2026-07-30T12:00:00Z")
         assert parsed == datetime(2026, 7, 30, 12, 0, 0, tzinfo=timezone.utc)
 
     def test_explicit_offset_is_converted_not_ignored(self):
         """+02:00 is two hours ahead of the same wall-clock time in UTC."""
-        offset = parse_sync_time("2026-07-30T12:00:00+02:00")
-        utc = parse_sync_time("2026-07-30T12:00:00Z")
+        offset = parse_timestamp("2026-07-30T12:00:00+02:00")
+        utc = parse_timestamp("2026-07-30T12:00:00Z")
         assert offset is not None and utc is not None
         assert offset == utc - timedelta(hours=2)
 
 
 class TestServerInstructions:
-    """The assistant learns the snapshot age from the server instructions."""
-
-    def test_instructions_state_the_snapshot_age(self, tmp_path):
+    def test_instructions_state_the_documentation_date(self, tmp_path):
         from laravel_mcp_companion import build_server_instructions
 
-        write_snapshot(tmp_path, 45)
-        instructions = build_server_instructions(tmp_path, "12.x")
+        write_metadata(tmp_path, "13.x", changed_days_ago=2)
+        instructions = build_server_instructions(tmp_path, "13.x")
 
-        assert "45 days ago" in instructions
-        assert "update_laravel_docs" in instructions, (
-            "instructions must tell the assistant how to refresh"
-        )
+        assert "reflects Laravel's documentation as of" in instructions
 
-    def test_instructions_report_the_served_version_not_the_freshest(self, tmp_path):
-        """The bug this guards: a pinned old version inheriting a newer one's date.
-
-        A user on 11.x whose docs are 101 days old must not be told the corpus
-        was synced today because 13.x happens to be current.
-        """
+    def test_instructions_do_not_call_an_eol_version_stale(self, tmp_path):
+        """8.x is byte-identical to upstream; the model must not be told to refresh."""
         from laravel_mcp_companion import build_server_instructions
 
-        write_snapshot(tmp_path, 101, version="11.x")
-        write_snapshot(tmp_path, 0, version="13.x")
+        write_metadata(tmp_path, "8.x", changed_days_ago=425)
+        instructions = build_server_instructions(tmp_path, "8.x")
 
-        instructions = build_server_instructions(tmp_path, "11.x")
+        assert "425 days ago" not in instructions
+        assert "stale" not in instructions.lower()
 
-        assert "101 days ago" in instructions
-        assert "(today)" not in instructions
+    def test_instructions_report_the_served_version(self, tmp_path):
+        from laravel_mcp_companion import build_server_instructions
+
+        write_metadata(tmp_path, "8.x", changed_days_ago=425)
+        write_metadata(tmp_path, "13.x", changed_days_ago=0)
+
+        instructions = build_server_instructions(tmp_path, "8.x")
+        eight, _ = get_documentation_date(tmp_path, "8.x")
+
+        assert eight in instructions
 
     def test_instructions_name_the_default_version_explicitly(self, tmp_path):
         from laravel_mcp_companion import build_server_instructions
 
-        write_snapshot(tmp_path, 1, version="11.x")
+        write_metadata(tmp_path, "11.x", changed_days_ago=1)
         instructions = build_server_instructions(tmp_path, "11.x")
 
         # The bare string "11.x" also appears in the supported-versions list, so
@@ -199,8 +199,8 @@ class TestServerInstructions:
         """
         from laravel_mcp_companion import build_server_instructions
 
-        write_snapshot(tmp_path, 1)
-        instructions = build_server_instructions(tmp_path, "12.x", transform_mode=mode)
+        write_metadata(tmp_path, "13.x", changed_days_ago=1)
+        instructions = build_server_instructions(tmp_path, "13.x", transform_mode=mode)
 
         assert expected in instructions
         assert forbidden not in instructions
@@ -208,16 +208,88 @@ class TestServerInstructions:
     def test_instructions_survive_missing_metadata(self, tmp_path):
         from laravel_mcp_companion import build_server_instructions
 
-        instructions = build_server_instructions(tmp_path, "12.x")
-        assert "unknown" in instructions
+        assert "unknown" in build_server_instructions(tmp_path, "13.x")
 
     def test_server_starts_with_corrupt_metadata(self, tmp_path):
         """Instructions are built during server construction, so this must not raise."""
         from laravel_mcp_companion import create_mcp_server
 
-        metadata_dir = tmp_path / "12.x" / ".metadata"
+        metadata_dir = tmp_path / "13.x" / ".metadata"
         metadata_dir.mkdir(parents=True)
-        (metadata_dir / "sync_info.json").write_text(json.dumps({"sync_time": 1753900000}))
+        (metadata_dir / "sync_info.json").write_text(json.dumps({"commit_date": 1753900000}))
 
-        server = create_mcp_server("Test", tmp_path, "12.x", transform_mode=None)
+        server = create_mcp_server("Test", tmp_path, "13.x", transform_mode=None)
         assert server is not None
+
+
+class TestDocsInfoTool:
+    @pytest.mark.asyncio
+    async def test_summary_does_not_warn_when_the_copy_is_current(self, tmp_path):
+        """The permanent-warning bug: 6.x can never get fresher."""
+        from fastmcp import Client
+
+        from laravel_mcp_companion import create_mcp_server
+
+        write_metadata(tmp_path, "6.x", changed_days_ago=425)
+        write_metadata(tmp_path, "13.x", changed_days_ago=1)
+
+        server = create_mcp_server("T", tmp_path, "13.x", transform_mode=None)
+        async with Client(server) as client:
+            result = await client.call_tool("laravel_docs_info", {})
+            text = result.content[0].text
+
+        assert "note" not in text, f"warned about a current copy: {text}"
+        assert "documentation_current_to" in text
+
+    @pytest.mark.asyncio
+    async def test_summary_warns_when_the_whole_copy_is_old(self, tmp_path):
+        from fastmcp import Client
+
+        from laravel_mcp_companion import create_mcp_server
+
+        write_metadata(tmp_path, "6.x", changed_days_ago=425)
+        write_metadata(tmp_path, "13.x", changed_days_ago=DOCS_STALE_AFTER_DAYS + 5)
+
+        server = create_mcp_server("T", tmp_path, "13.x", transform_mode=None)
+        async with Client(server) as client:
+            result = await client.call_tool("laravel_docs_info", {})
+            text = result.content[0].text
+
+        assert "note" in text
+        assert "pull" in text.lower(), "should advise pulling a newer image"
+        assert "update_laravel_docs" not in text, "that tool cannot fix a stale image"
+
+    @pytest.mark.asyncio
+    async def test_per_version_reports_a_date_and_never_warns(self, tmp_path):
+        from fastmcp import Client
+
+        from laravel_mcp_companion import create_mcp_server
+
+        write_metadata(tmp_path, "8.x", changed_days_ago=425)
+
+        server = create_mcp_server("T", tmp_path, "8.x", transform_mode=None)
+        async with Client(server) as client:
+            result = await client.call_tool("laravel_docs_info", {"version": "8.x"})
+            text = result.content[0].text
+
+        assert "documentation_date" in text
+        assert "note" not in text, "a version whose upstream stopped is not a problem"
+
+
+class TestUpdateToolParameterName:
+    @pytest.mark.asyncio
+    async def test_accepts_the_parameter_name_every_other_tool_uses(self, tmp_path):
+        """An assistant told to refresh guesses `version`; it used to hard-error."""
+        from fastmcp import Client
+
+        from laravel_mcp_companion import create_mcp_server
+
+        write_metadata(tmp_path, "13.x", changed_days_ago=1)
+        server = create_mcp_server("T", tmp_path, "13.x", transform_mode=None)
+
+        async with Client(server) as client:
+            tools = {t.name: t for t in await client.list_tools()}
+            schema = tools["update_laravel_docs"].inputSchema
+
+        assert "version" in schema["properties"]
+        assert "version_param" not in schema["properties"]


### PR DESCRIPTION
Stacked on #387 (which is stacked on #386). Review the last two commits; the base will collapse as those merge.

## The bug

`sync_time` records when this project last *fetched* a change, not when the documentation last *changed*. `DocsUpdater.update()` returns early when the upstream SHA matches (`docs_updater.py:1704`) and never rewrites metadata, so for a branch Laravel no longer touches that timestamp recedes forever.

Every one of the eight shipped versions matches `laravel/docs` branch HEAD exactly — verified against the GitHub API. Despite that, **five of eight were reported stale**, the warning **could not be cleared** (the recommended tool returns "already up to date" and leaves `sync_time` untouched), and the recommended tool **rejected the obvious argument** — every other tool takes `version`, this one exposed `version_param`, so `version='9.x'` raised `ToolError`. `laravel_docs_info()` reported the *oldest* version's age — 425 days — and warned permanently, because 6.x can never get fresher.

Net effect: the assistant hedged on correct documentation and was told to run a tool that could not help.

## The fix

Report `commit_date` — the date Laravel last changed that documentation. True for an end-of-life branch, needs no network, and answers the question the assistant actually has: whether the corpus predates the feature being asked about.

Staleness now judges the *copy*, not a version. Laravel changes 13.x most days, so the newest `commit_date` across all versions is an offline proxy for how old this copy is. The warning fires only when nothing has changed anywhere, and says to pull a newer image. `copy_is_stale` takes no version argument, so the meaningless per-version question cannot be asked.

`describe_documentation_date` returns a bare date with no age phrasing — rendering "425 days ago" would reintroduce exactly the alarm being removed, factual or not.

## Real output, after

```
documentation_current_to: 2026-07-30
copy_age_days: 0
default_version: 13.x
versions[8]{version,documentation_date,last_updated,commit,available}:
  6.x,2024-09-18,"2025-09-19T01:19:17Z",c9b5dfb,true
  8.x,2025-04-01,"2025-06-01T02:03:39Z",13bfbca,true
  13.x,2026-07-30,"2026-07-31T00:04:25Z",ebeea7c,true
```

No warning. Serving 8.x now says: *"This copy reflects Laravel's documentation as of 2025-04-01. If you are asked about a feature that may have been added after that date, say so..."*

## Breaking

- `update_laravel_docs(version=...)` replaces `version_param`. The surface being broken never worked by name.
- `laravel_docs_info` reports `documentation_date` per version and `documentation_current_to` / `copy_age_days` in the summary.

## Testing

648 pass, ruff and mypy clean. Written failing-first; both key assertions were mutation-tested — reverting to `sync_time` and switching newest-to-oldest each break the tests that exist to catch them. The regression is pinned directly: a version whose `commit_date` is old but which matches upstream is not reported as stale, and `laravel_docs_info()` does not warn when the newest version is current.

Coverage dropped in the rewrite (timezone handling, non-object metadata, per-mode instruction surface, corrupt-metadata startup) was restored rather than lost.

Spec: `docs/superpowers/specs/2026-07-31-documentation-currency-design.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documentation information now shows upstream documentation dates and overall copy age.
  * Added clearer section-based documentation search and section reading.
  * Refresh and information tools now use the `version` parameter.

* **Bug Fixes**
  * Improved stale documentation detection using upstream change dates.
  * Corrected documentation date and version metadata reporting.

* **Tests**
  * Added coverage for date handling, version scenarios, server guidance, and configuration consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->