### PR TITLE
Stop documentation syncs from busting the Docker dependency layer

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# Keep the build context to what the image actually needs. docs/ is deliberately
+# absent from this list -- the documentation corpus is the product.
+
+# Version control
+.git
+.gitignore
+.github
+
+# Local virtualenvs and caches
+.venv
+venv
+__pycache__
+*.py[cod]
+.pytest_cache
+.mypy_cache
+.ruff_cache
+.coverage
+coverage.xml
+htmlcov
+
+# Tests and development-only tooling
+tests
+requirements-dev.txt
+pytest.ini
+.python-version
+
+# CI/CD definitions
+.harness
+
+# Working notes that ship no runtime value
+docs/superpowers
+
+# Editor and OS noise
+.vscode
+.idea
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,17 @@ RUN apk add --no-cache build-base libffi-dev openssl-dev git
 # Set working directory
 WORKDIR /app
 
-# Copy project files
-COPY . .
-
-# Install Python dependencies including HTTP server requirements
+# Dependencies first, and on their own. Documentation syncs land daily and touch
+# only docs/, so copying the whole tree before this would invalidate the install
+# layer every single day -- every user pulling :latest would re-download every
+# dependency for a content-only change.
+COPY requirements.txt ./
 RUN pip install --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt
+
+# Now the source and the documentation corpus. Only this layer changes on a
+# documentation sync.
+COPY . .
 
 # Default environment
 ENV PYTHONUNBUFFERED=1

--- a/tests/unit/test_dockerfile.py
+++ b/tests/unit/test_dockerfile.py
@@ -1,0 +1,72 @@
+"""The image must not rebuild its dependency layer for a documentation change.
+
+Documentation syncs land daily and touch only `docs/`. Whether that costs users
+a dependency re-download is decided entirely by the order of two lines in the
+Dockerfile, which is exactly the kind of thing that gets reordered by accident.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def dockerfile_lines() -> list[str]:
+    text = (REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
+    # Join continuations so a multi-line RUN is one logical instruction.
+    text = re.sub(r"\\\n\s*", " ", text)
+    return [line for line in (raw.strip() for raw in text.splitlines())
+            if line and not line.startswith("#")]
+
+
+def index_of(pattern: str) -> int:
+    for i, line in enumerate(dockerfile_lines()):
+        if re.search(pattern, line):
+            return i
+    raise AssertionError(f"no Dockerfile instruction matches {pattern!r}")
+
+
+class TestLayerOrdering:
+    def test_dependencies_install_before_the_source_copy(self):
+        """The regression this file exists to prevent.
+
+        With `COPY . .` above `pip install`, the daily documentation commit
+        invalidates the dependency layer too, so everyone pulling :latest
+        re-downloads every dependency for a content-only change.
+        """
+        assert index_of(r"pip install.*requirements\.txt") < index_of(r"^COPY \. \."), (
+            "COPY . . must come after the dependency install, or a docs-only "
+            "change busts the dependency layer for every user"
+        )
+
+    def test_requirements_are_copied_before_they_are_installed(self):
+        assert index_of(r"^COPY .*requirements") < index_of(r"pip install.*requirements\.txt")
+
+    def test_requirements_are_copied_without_the_rest_of_the_tree(self):
+        """Copying the tree to get requirements.txt would defeat the ordering."""
+        lines = dockerfile_lines()
+        copy = lines[index_of(r"^COPY .*requirements")]
+        assert not re.match(r"^COPY \s*\.\s", copy), (
+            f"{copy!r} copies the whole context; copy only the requirements files"
+        )
+
+
+class TestDockerignore:
+    @pytest.mark.parametrize("unwanted", [".git", ".venv", "htmlcov", "__pycache__"])
+    def test_build_context_excludes_local_only_directories(self, unwanted):
+        """.venv alone is 219MB, and none of these belong in a published image."""
+        path = REPO_ROOT / ".dockerignore"
+        assert path.exists(), ".dockerignore is missing; the build context ships .git and .venv"
+
+        entries = {line.strip().strip("/") for line in path.read_text().splitlines()
+                   if line.strip() and not line.startswith("#")}
+        assert unwanted in entries, f"{unwanted} is not excluded from the build context"
+
+    def test_the_documentation_corpus_is_still_shipped(self):
+        """The docs ARE the product. Excluding them would produce an empty server."""
+        entries = {line.strip().strip("/") for line
+                   in (REPO_ROOT / ".dockerignore").read_text().splitlines()
+                   if line.strip() and not line.startswith("#")}
+        assert "docs" not in entries


### PR DESCRIPTION
## The cost

`COPY . .` sat above `pip install` in the Dockerfile. Documentation syncs land **daily** and touch only `docs/`, but that ordering meant each one invalidated the dependency layer too — so every user pulling `:latest` re-downloaded every dependency for a content-only change.

Copying `requirements.txt` on its own first means a documentation sync changes exactly one layer.

## The build context

There was no `.dockerignore`, so `.git` (8.9 MB), `.venv` (219 MB), `htmlcov` (5.2 MB), `__pycache__`, the test suite, and the Harness pipeline definitions were all being sent to the builder and baked into the image. Context drops from **20,191 files to 1,103** (24.4 MB).

`docs/` is deliberately **not** excluded — the documentation corpus is the product. There's a test asserting that, because "exclude the big directory" is a tempting and catastrophic edit.

## Measured results

Built and verified locally on Docker 29.6.1 (linux/aarch64).

**Layer caching**, after a docs-only change (`echo "" >> docs/13.x/queues.md`):

| Dockerfile | `RUN pip install` |
|---|---|
| this branch | `CACHED` |
| `main` | re-runs |

**Image size:**

```
lmc:truly-old   1.33GB
lmc:new          677MB
```

⚠️ A note on how that size number was obtained, because the obvious method is wrong: building the old Dockerfile with `-f Dockerfile.old` from this branch's directory reports **677MB for both**. `.dockerignore` applies to the build *context* regardless of which Dockerfile is passed, so the "old" build silently gets the fix. A valid comparison requires moving `.dockerignore` aside and rebuilding with `--no-cache`.

**The container works end to end.** A real MCP session against the built image (`docker run --rm -i lmc:new`, stdio transport):

```
tools: ['call_tool', 'search_laravel_docs', 'search_tools']
documentation_current_to: 2026-07-30
copy_age_days: 0
search head: query: how do I retry a failed queue job
```

The documentation corpus ships intact and the v0.11.0 currency reporting works inside the container — which is the failure mode that mattered here, since a `.dockerignore` that swallowed `docs/` would produce an empty server that still builds and starts.

## Tests

8 new tests, written failing-first, all 8 red before the change:

- dependencies install before the source copy (the regression itself)
- `requirements.txt` is copied before it's installed
- that copy doesn't drag in the whole tree, which would defeat the ordering
- `.git` / `.venv` / `htmlcov` / `__pycache__` are excluded
- `docs` is **not** excluded

670 tests pass overall; ruff clean.

## Follow-up worth considering

Nothing in CI builds the image, so the first build of any Dockerfile change is the next release — where a mistake breaks the release rather than a PR. I verified this one by hand; a CI image build would make that automatic. Happy to add it separately.