### PR TITLE
Stop the tool surface describing itself falsely

### DIFF
--- a/laravel_mcp_companion.py
+++ b/laravel_mcp_companion.py
@@ -419,7 +419,7 @@ When to use:
 - Checking which versions have specific documentation
 - Getting an overview of documentation coverage""",
 
-    "read_laravel_doc_content": """Reads the complete content of a specific Laravel documentation file. This is the primary tool for accessing actual documentation content.
+    "read_laravel_doc_content": """Reads a whole Laravel documentation file. Prefer read_laravel_doc_section, which returns just the section you need -- a full file can exceed 30,000 tokens against a few hundred for one section.
 
 When to use:
 - Reading full documentation for a feature
@@ -433,14 +433,6 @@ When to use:
 - Finding which files mention a specific feature
 - Quick lookup of where topics are discussed
 - Discovering related documentation files""",
-
-    "search_laravel_docs_with_context": """Advanced search that returns matching text with surrounding context. Shows exactly how terms are used in documentation.
-
-When to use:
-- Understanding how a feature is described
-- Finding specific code examples
-- Getting quick answers without reading full files
-- Seeing usage context for technical terms""",
 
     "get_doc_structure": """Extracts the table of contents and structure from a documentation file. Shows headers and brief content previews.
 
@@ -1746,7 +1738,7 @@ def configure_mcp_server(mcp: FastMCP, docs_path: Path, runtime_version: str, mu
         })
 
     @mcp.tool(
-        description="Read the full content of a specific Laravel documentation file",
+        description=TOOL_DESCRIPTIONS["read_laravel_doc_content"],
         annotations={"readOnlyHint": True, "idempotentHint": True},
         tags={"docs", "read"}
     )
@@ -1786,7 +1778,7 @@ def configure_mcp_server(mcp: FastMCP, docs_path: Path, runtime_version: str, mu
         )
 
     @mcp.tool(
-        description="Get the structure and sections of a documentation file",
+        description=TOOL_DESCRIPTIONS["get_doc_structure"],
         annotations={"readOnlyHint": True, "idempotentHint": True},
         tags={"docs", "read"}
     )
@@ -1804,7 +1796,7 @@ def configure_mcp_server(mcp: FastMCP, docs_path: Path, runtime_version: str, mu
         return get_doc_structure_impl(docs_path, filename, version, runtime_version=runtime_version)
 
     @mcp.tool(
-        description="Browse Laravel documentation by category",
+        description=TOOL_DESCRIPTIONS["browse_docs_by_category"],
         annotations={"readOnlyHint": True, "idempotentHint": True},
         tags={"docs", "read"}
     )
@@ -2249,9 +2241,15 @@ def apply_transforms(mcp: FastMCP, transform_mode: Optional[str] = "search") -> 
     elif transform_mode == "search":
         mcp.add_transform(BM25SearchTransform(
             max_results=10,
-            always_visible=["search_laravel_docs"],
+            # Search returns section anchors; reading one is the other half of
+            # the same move. Leaving the reader behind a search_tools lookup put
+            # a round trip in the middle of the most common path.
+            always_visible=["search_laravel_docs", "read_laravel_doc_section"],
         ))
-        logger.info("BM25 Search transform applied (max_results=10, search_laravel_docs pinned)")
+        logger.info(
+            "BM25 Search transform applied (max_results=10; search_laravel_docs "
+            "and read_laravel_doc_section pinned)"
+        )
     else:
         raise ValueError(f"Unknown transform_mode: {transform_mode!r}. Use 'search', 'code', or None.")
 

--- a/mcp_tools.py
+++ b/mcp_tools.py
@@ -1180,7 +1180,7 @@ def search_laravel_learning_resources_impl(
     if not learning_dir.exists():
         return format_error(
             "No learning resources found",
-            {"suggestion": "Use update_learning_docs() to fetch learning resources first"}
+            {"suggestion": "Learning resources ship with the server; this documentation path is missing them. Check DOCS_PATH, or the mount if running in Docker."}
         )
 
     results_data: List[Dict] = []
@@ -1251,7 +1251,7 @@ def list_laravel_learning_resources_impl(docs_path: Path, source: Optional[str] 
     if not learning_dir.exists():
         return format_error(
             "No learning resources found",
-            {"suggestion": "Use update_learning_docs() to fetch learning resources first"}
+            {"suggestion": "Learning resources ship with the server; this documentation path is missing them. Check DOCS_PATH, or the mount if running in Docker."}
         )
 
     if source:

--- a/tests/unit/test_tool_surface.py
+++ b/tests/unit/test_tool_surface.py
@@ -1,0 +1,113 @@
+"""The tool surface must describe itself honestly.
+
+Every defect here is the same shape: the server tells the assistant something
+about its own tools that is not true. That cost a release already -- v0.10.0
+advertised `update_laravel_docs(version_param=...)`, an argument no caller could
+successfully pass, and an assistant following the advice hard-errored.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+from fastmcp import Client
+
+from laravel_mcp_companion import TOOL_DESCRIPTIONS, create_mcp_server
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+PRODUCT_MODULES = ["laravel_mcp_companion.py", "mcp_tools.py", "docs_updater.py"]
+
+
+@pytest.fixture
+async def tool_names(tmp_path):
+    server = create_mcp_server("Test", tmp_path, "13.x", transform_mode=None)
+    async with Client(server) as client:
+        return {tool.name for tool in await client.list_tools()}
+
+
+class TestNoPhantomTools:
+    @pytest.mark.asyncio
+    async def test_error_messages_only_name_tools_that_exist(self, tool_names):
+        """Two error paths advised calling `update_learning_docs()`, which is not
+        a tool -- it is a DocsUpdater method reachable only through
+        `update_all_docs()`, which nothing exposes. A user hitting that error had
+        no way to act on the advice.
+        """
+        advised = set()
+        for module in PRODUCT_MODULES:
+            text = (REPO_ROOT / module).read_text(encoding="utf-8")
+            advised |= set(re.findall(r"Use (\w+)\(\) to", text))
+
+        phantom = advised - tool_names
+        assert not phantom, (
+            f"error messages tell the assistant to call {sorted(phantom)}, "
+            f"which are not registered tools"
+        )
+
+
+class TestPinnedTools:
+    @pytest.mark.asyncio
+    async def test_reading_a_section_is_reachable_without_a_lookup(self, tmp_path):
+        """Search returns section anchors; reading one is the other half.
+
+        With only `search_laravel_docs` pinned, the single most common path --
+        search, then read the section it just pointed at -- costs a `search_tools`
+        round trip in between.
+        """
+        server = create_mcp_server("Test", tmp_path, "13.x", transform_mode="search")
+        async with Client(server) as client:
+            visible = {tool.name for tool in await client.list_tools()}
+
+        assert "search_laravel_docs" in visible
+        assert "read_laravel_doc_section" in visible, (
+            f"search results are unreadable without a lookup; visible: {sorted(visible)}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_pinned_surface_stays_small(self, tmp_path):
+        """Pinning everything would defeat the transform's purpose."""
+        server = create_mcp_server("Test", tmp_path, "13.x", transform_mode="search")
+        async with Client(server) as client:
+            visible = {tool.name for tool in await client.list_tools()}
+
+        assert len(visible) <= 5, f"too many tools pinned: {sorted(visible)}"
+
+
+class TestToolDescriptions:
+    @pytest.mark.asyncio
+    async def test_every_description_belongs_to_a_real_tool(self, tool_names):
+        """`search_laravel_docs_with_context` was removed in v0.11.0; its
+        description outlived it."""
+        orphaned = set(TOOL_DESCRIPTIONS) - tool_names
+        assert not orphaned, f"TOOL_DESCRIPTIONS describes tools that no longer exist: {sorted(orphaned)}"
+
+    @pytest.mark.asyncio
+    async def test_tools_use_the_description_written_for_them(self, tmp_path):
+        """Three tools were registered with one-line summaries while their real
+        descriptions sat unused. That is not cosmetic: BM25SearchTransform
+        indexes descriptions, so an unwired tool is harder to discover in the
+        default mode.
+        """
+        server = create_mcp_server("Test", tmp_path, "13.x", transform_mode=None)
+        async with Client(server) as client:
+            registered = {tool.name: (tool.description or "") for tool in await client.list_tools()}
+
+        mismatched = [
+            name for name, expected in TOOL_DESCRIPTIONS.items()
+            if name in registered and registered[name].strip() != expected.strip()
+        ]
+        assert not mismatched, (
+            f"these tools have a description in TOOL_DESCRIPTIONS but do not use it: {sorted(mismatched)}"
+        )
+
+    def test_no_description_claims_to_be_the_primary_read_path(self):
+        """`read_laravel_doc_content` called itself "the primary tool for
+        accessing actual documentation content". Since v0.11.0 that is
+        `read_laravel_doc_section`; whole-file reads cost roughly ten times as
+        much and are the fallback.
+        """
+        content = TOOL_DESCRIPTIONS.get("read_laravel_doc_content", "")
+        assert "primary tool" not in content.lower(), (
+            "read_laravel_doc_content is no longer the primary read path"
+        )


### PR DESCRIPTION
Three defects, all the same shape: **the server tells the assistant something about its own tools that is not true.** That shape cost a release already — v0.10.0 advertised `update_laravel_docs(version_param=...)`, an argument no caller could successfully pass.

## `update_learning_docs()` does not exist

Two error paths (`mcp_tools.py:1183`, `:1254`) advised *"Use `update_learning_docs()` to fetch learning resources first."* It isn't a tool. It's a `DocsUpdater` method reachable only through `update_all_docs()`, which nothing exposes — I checked the full registered surface, and there is **no** MCP tool that populates `learning_resources/`.

So there's no correct tool name to swap in. The message now says what's actually true: learning resources ship with the server, and their absence means the documentation path is wrong.

The test for this is deliberately **generic** rather than pinned to this one string — any error message advising a call the server doesn't expose now fails.

## Search results were unreadable without a lookup

Only `search_laravel_docs` was pinned in search mode. Since v0.11.0, search returns section anchors and `read_laravel_doc_section` reads one — two halves of the same move. Leaving the reader behind a `search_tools` → `call_tool` lookup put a round trip in the middle of the most common path.

```
before: ['call_tool', 'search_laravel_docs', 'search_tools']
after:  ['call_tool', 'read_laravel_doc_section', 'search_laravel_docs', 'search_tools']
```

There's a test capping the pinned surface at 5, since pinning everything defeats the transform.

## Four `TOOL_DESCRIPTIONS` entries were wrong or unused

- `search_laravel_docs_with_context` — the tool was removed in v0.11.0; its description outlived it. Deleted.
- `read_laravel_doc_content`, `get_doc_structure`, `browse_docs_by_category` — live tools registered with one-line summaries while their real "When to use" descriptions sat unused. Now wired.

This isn't cosmetic: `BM25SearchTransform` **indexes tool descriptions**, so an unwired tool is measurably harder to discover in the default mode.

While wiring it, `read_laravel_doc_content` still called itself *"the primary tool for accessing actual documentation content."* Since v0.11.0 that's `read_laravel_doc_section` — a whole file can exceed 30,000 tokens against a few hundred for a section — so I rewrote the opening to point at the cheaper path rather than shipping the stale claim verbatim.

## Tests

6 new tests, written failing-first; 5 red before the change (the 6th, the pinned-surface cap, correctly passed already). 668 pass overall; ruff and mypy clean.