### PR TITLE
Build the Docker image in CI

### DIFF
--- a/.harness/orgs/default/projects/laravel_mcp_companion/pipelines/ci.yaml
+++ b/.harness/orgs/default/projects/laravel_mcp_companion/pipelines/ci.yaml
@@ -112,6 +112,33 @@ pipeline:
                         paths:
                           - results.xml
               - step:
+                  identifier: docker_build
+                  name: Build Docker image
+                  type: Run
+                  spec:
+                    shell: Bash
+                    command: |
+                      set -euo pipefail
+
+                      # Nothing built the image for the life of the project, so
+                      # the first real build of a Dockerfile change was the next
+                      # release -- where a mistake breaks the release rather than
+                      # a pull request. Build it here instead.
+                      #
+                      # Single-arch on purpose. This validates the Dockerfile;
+                      # the release pipeline does the multi-arch buildx run, and
+                      # emulating arm64 here would cost minutes for no extra
+                      # signal. No push either: publishing is the release
+                      # pipeline's job.
+                      docker build -t laravel-mcp-companion:ci .
+
+                      # A build proves the image assembles, not that it runs.
+                      # Starting it catches a broken entrypoint, a missing
+                      # runtime dependency, and a .dockerignore that swallowed
+                      # something the server needs.
+                      docker run --rm laravel-mcp-companion:ci --help > /dev/null
+                      echo "image builds and starts"
+              - step:
                   identifier: mcp_inspector_smoke_test
                   name: MCP Inspector smoke test
                   type: Run

--- a/tests/unit/test_dockerfile.py
+++ b/tests/unit/test_dockerfile.py
@@ -70,3 +70,36 @@ class TestDockerignore:
                    in (REPO_ROOT / ".dockerignore").read_text().splitlines()
                    if line.strip() and not line.startswith("#")}
         assert "docs" not in entries
+
+
+class TestImageIsBuiltInCI:
+    """Nothing built the image for the life of the project.
+
+    The first real build of any Dockerfile change was the next release, where a
+    mistake breaks the release rather than a pull request. That is how the
+    layer-ordering defect above survived: it was never wrong enough to fail a
+    build, and no build ran anyway.
+    """
+
+    def ci_pipeline(self) -> str:
+        path = (REPO_ROOT / ".harness/orgs/default/projects/laravel_mcp_companion"
+                / "pipelines/ci.yaml")
+        assert path.exists(), f"CI pipeline definition not found at {path}"
+        return path.read_text(encoding="utf-8")
+
+    def test_ci_builds_the_image(self):
+        assert re.search(r"docker\s+build", self.ci_pipeline()), (
+            "CI must build the image, or Dockerfile changes reach users unbuilt"
+        )
+
+    def test_ci_does_not_push_from_a_pull_request(self):
+        """Validation only. Publishing is the release pipeline's job."""
+        ci = self.ci_pipeline()
+        assert "BuildAndPushDockerRegistry" not in ci
+        assert not re.search(r"docker\s+push", ci)
+
+    def test_the_built_image_is_actually_started(self):
+        """A build proves the image assembles, not that it runs."""
+        assert re.search(r"docker\s+run", self.ci_pipeline()), (
+            "CI should start the image it just built"
+        )


### PR DESCRIPTION
Closes the gap flagged in #390.

## Why

**Nothing built the image for the life of the project.** The first real build of any Dockerfile change was the next release — where a mistake breaks the release rather than a pull request.

That's exactly how the layer-ordering defect in #390 survived: it was never *wrong* enough to fail a build, and no build ran anyway. I only caught it by hand, and only verified the fix because Docker happened to be available locally.

## What

A `Run` step in the CI stage that builds the image and starts it.

- **Single-arch, no push.** This validates the Dockerfile. The release pipeline still does the multi-arch buildx run and the publishing; emulating arm64 here would cost minutes for no extra signal.
- **It starts the image, not just builds it.** A build proves the image assembles, not that it runs. Starting it catches a broken entrypoint, a missing runtime dependency, and — the one that matters most here — a `.dockerignore` that swallowed something the server needs. That failure mode produces an image which builds *and* starts happily while serving nothing.

## Tests

3 guards added to `test_dockerfile.py`, 2 red before the change:

- CI builds the image
- CI does **not** push from a PR (publishing stays the release pipeline's job)
- CI starts the image it built

## Verification

⚠️ The one thing I cannot check locally is whether a Docker daemon is available to a `Run` step on the Harness Cloud runtime. If it isn't, this step fails and I'll switch approach — I'm watching the actual pipeline run on this PR and will confirm from the execution log before asking for a merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation that the continuous integration pipeline builds the Docker image successfully.
  * Confirmed pull request builds do not push images.
  * Verified the built image starts correctly and responds to the help command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->