### PR TITLE
v0.13.0: health and metrics endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ docs-only commit and contains no code change.
 ## [Unreleased]
 
 ### Added
+- Operational endpoints for the HTTP transport: `GET /healthz` (public
+  liveness/readiness JSON — `degraded` flags a stale corpus at 200, 503 is
+  reserved for no readable documentation) and `GET /metrics` (Prometheus
+  text: per-tool call counters, a latency histogram, request counts, uptime,
+  documentation age). Metrics require a bearer token whenever auth is
+  configured; collection runs through FastMCP middleware with no per-tool
+  code changes and no new dependencies.
 - End-to-end tests that spawn the real server over stdio and HTTP —
   initialize, search-to-section flows, `.well-known` discovery, Host
   rejection, and bearer auth, all through real transports (`pytest -m e2e`).

--- a/README.md
+++ b/README.md
@@ -215,6 +215,17 @@ python laravel_mcp_companion.py --transport http \
 
 Requests with an unrecognized `Host` get `421`; requests from an unlisted `Origin` get `403`. Passing `--allowed-host` or `--cors-origin` on the command line replaces the corresponding environment variable rather than adding to it. If you expose this beyond localhost, put an authenticating reverse proxy in front of it. Avoid `--transform-mode code` over HTTP entirely — `execute` is a code execution endpoint.
 
+### Operational endpoints (HTTP mode)
+
+- **`GET /healthz`** — liveness/readiness JSON, always public (load balancers
+  can't do OAuth). `ok` and `degraded` both return 200 — degraded means the
+  documentation copy is stale and a newer image should be pulled; 503 means no
+  documentation is readable and traffic should not be routed here.
+- **`GET /metrics`** — Prometheus text format: per-tool call counters, a
+  latency histogram, request counts, uptime, and documentation age. Public on
+  unauthenticated deployments; requires a valid bearer token whenever auth is
+  configured.
+
 
 ## Features (v0.12.0)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -162,7 +162,7 @@ retrieval overhaul in v0.11.0 already delivered the highest-value part.
 - [ ] Package ecosystem documentation mapping
 
 ### Reliability & Monitoring
-- [ ] Health monitoring and metrics endpoints
+- [x] Health monitoring and metrics endpoints *(/healthz + Prometheus /metrics, HTTP mode)*
 - [ ] Rate limiting and quota management
 - [ ] Error recovery and graceful degradation improvements
 - [x] Performance optimization and caching improvements *(delivered in v0.10.0)*

--- a/laravel_mcp_companion.py
+++ b/laravel_mcp_companion.py
@@ -1362,6 +1362,29 @@ def fuzzy_search(query: str, text: str, threshold: float = 0.6) -> List[Dict]:
     return sorted(matches, key=lambda x: x['score'], reverse=True)
 
 
+def harden_verifier(verifier: "TokenVerifier") -> "TokenVerifier":
+    """Make verify_token fail closed instead of raising.
+
+    FastMCP's auth middleware eagerly verifies any request that carries an
+    Authorization header — on every route, custom ones included — and an
+    exception from the verifier (a JWKS fetch failing, say) becomes an
+    app-wide 500, taking /healthz and /.well-known down with it. Catching
+    here turns an outage into 401s for token-bearing requests while every
+    public route keeps answering.
+    """
+    inner = verifier.verify_token
+
+    async def resilient(token: str):
+        try:
+            return await inner(token)
+        except Exception as e:
+            logger.error(f"Token verification failed closed: {e}")
+            return None
+
+    verifier.verify_token = resilient  # type: ignore[method-assign]
+    return verifier
+
+
 def build_auth_provider(args) -> Optional["TokenVerifier"]:
     """Build the OAuth 2.1 token verifier from CLI/env configuration.
 
@@ -1405,12 +1428,12 @@ def build_auth_provider(args) -> Optional["TokenVerifier"]:
             sys.exit(1)
         from fastmcp.server.auth.providers.jwt import JWTVerifier
         logger.info(f"Bearer-token auth enabled (JWKS: {args.auth_jwks_uri})")
-        return JWTVerifier(
+        return harden_verifier(JWTVerifier(
             jwks_uri=args.auth_jwks_uri,
             issuer=args.auth_issuer,
             audience=args.auth_audience,
             required_scopes=args.auth_required_scope or None,
-        )
+        ))
 
     tokens: Dict[str, Dict[str, Any]] = {}
     for entry in static_tokens.split(","):
@@ -1426,7 +1449,7 @@ def build_auth_provider(args) -> Optional["TokenVerifier"]:
         "Static-token auth enabled; fine for development, use --auth-jwks-uri "
         "with a real authorization server in production"
     )
-    return StaticTokenVerifier(tokens=tokens, required_scopes=args.auth_required_scope or None)
+    return harden_verifier(StaticTokenVerifier(tokens=tokens, required_scopes=args.auth_required_scope or None))
 
 
 def _registry_metadata() -> Dict[str, Any]:
@@ -1535,7 +1558,8 @@ def create_mcp_server(server_name: str, docs_path: Path, runtime_version: str, t
             "docs": {
                 "versions_available": versions_available,
                 "documentation_current_to": current_to or "unknown",
-                "copy_age_days": age if age is not None else "unknown",
+                # Numeric or null, never a string: monitors parse this field.
+                "copy_age_days": age,
                 "stale": stale,
             },
         }, code
@@ -1555,6 +1579,10 @@ def create_mcp_server(server_name: str, docs_path: Path, runtime_version: str, t
         if auth is not None:
             header = request.headers.get("authorization", "")
             token = header[7:] if header.lower().startswith("bearer ") else ""
+            # verify_token is hardened at construction (see harden_verifier):
+            # a verifier-side outage returns None rather than raising, so it
+            # reads as 401 here — same as FastMCP's own middleware, which
+            # verifies first on any request carrying an Authorization header.
             if not token or await auth.verify_token(token) is None:
                 return Response(
                     "unauthorized\n", status_code=401,

--- a/laravel_mcp_companion.py
+++ b/laravel_mcp_companion.py
@@ -20,7 +20,11 @@ import anyio.to_thread
 from fastmcp import Context, FastMCP
 from fastmcp.server.auth import TokenVerifier
 from starlette.requests import Request
-from starlette.responses import JSONResponse
+from starlette.responses import JSONResponse, Response
+
+import time
+
+from metrics import MetricsMiddleware, registry as metrics_registry, render_prometheus
 from fastmcp.server.transforms.search import BM25SearchTransform
 from mcp.types import Icon
 
@@ -1495,6 +1499,72 @@ def create_mcp_server(server_name: str, docs_path: Path, runtime_version: str, t
     @mcp.custom_route("/.well-known/mcp/server.json", methods=["GET"])
     async def well_known_server_json(request: "Request") -> "JSONResponse":
         return JSONResponse(_registry_metadata())
+
+    # Metrics collection is always on (negligible overhead: one lock and a
+    # clock read per call) so the HTTP endpoints never lie about "since when".
+    mcp.add_middleware(MetricsMiddleware())
+    start_time = time.monotonic()
+    metrics_registry.set_info(SERVER_VERSION)
+    metrics_registry.set_gauge_callable(
+        "laravel_mcp_uptime_seconds",
+        lambda: round(time.monotonic() - start_time, 3),
+    )
+
+    def _docs_age_days() -> Optional[float]:
+        _, age = get_documentation_date(docs_path)
+        return float(age) if age is not None else None
+
+    metrics_registry.set_gauge_callable("laravel_mcp_docs_copy_age_days", _docs_age_days)
+
+    def _health_payload() -> tuple[Dict[str, Any], int]:
+        versions_available = sum(
+            1 for v in SUPPORTED_VERSIONS if (docs_path / v).is_dir() and any((docs_path / v).glob("*.md"))
+        )
+        current_to, age = get_documentation_date(docs_path)
+        stale = copy_is_stale(docs_path)
+        if versions_available == 0:
+            status, code = "unhealthy", 503
+        elif stale:
+            status, code = "degraded", 200
+        else:
+            status, code = "ok", 200
+        return {
+            "status": status,
+            "version": SERVER_VERSION,
+            "uptime_seconds": round(time.monotonic() - start_time, 3),
+            "docs": {
+                "versions_available": versions_available,
+                "documentation_current_to": current_to or "unknown",
+                "copy_age_days": age if age is not None else "unknown",
+                "stale": stale,
+            },
+        }, code
+
+    # Always public: load balancers cannot do OAuth. "degraded" (stale corpus)
+    # still serves traffic; 503 is reserved for "no documentation readable".
+    @mcp.custom_route("/healthz", methods=["GET"])
+    async def healthz(request: "Request") -> "JSONResponse":
+        payload, code = _health_payload()
+        return JSONResponse(payload, status_code=code)
+
+    # Custom routes bypass FastMCP's auth middleware (the .well-known route
+    # relies on that), so this route enforces its own check with the same
+    # TokenVerifier the MCP endpoint uses — token semantics cannot drift.
+    @mcp.custom_route("/metrics", methods=["GET"])
+    async def metrics_endpoint(request: "Request") -> "Response":
+        if auth is not None:
+            header = request.headers.get("authorization", "")
+            token = header[7:] if header.lower().startswith("bearer ") else ""
+            if not token or await auth.verify_token(token) is None:
+                return Response(
+                    "unauthorized\n", status_code=401,
+                    headers={"WWW-Authenticate": "Bearer"},
+                    media_type="text/plain",
+                )
+        return Response(
+            render_prometheus(metrics_registry),
+            media_type="text/plain; version=0.0.4; charset=utf-8",
+        )
 
     # Initialize multi-source documentation updater
     multi_updater = MultiSourceDocsUpdater(docs_path, runtime_version)

--- a/metrics.py
+++ b/metrics.py
@@ -1,0 +1,161 @@
+"""Metrics collection and Prometheus exposition for Laravel MCP Companion.
+
+A deliberately small, dependency-free implementation: the metric set is fixed
+(see docs/superpowers/specs/2026-08-03-health-metrics-endpoints-design.md),
+label values come from closed sets (registered tool names, MCP method names),
+and rendering is deterministic so tests can golden-match it.
+
+Counters reset with the process; that is the Prometheus model
+(scrape-and-restart), not a bug.
+"""
+
+import threading
+import time
+from typing import Any, Callable, Dict, Optional, Tuple
+
+from fastmcp.server.middleware import Middleware
+
+# Latency buckets in seconds. One histogram overall rather than per tool:
+# per-tool histograms would be ~26x the cardinality for little added signal;
+# per-tool counters plus one duration distribution answer the real questions.
+BUCKETS = (0.005, 0.025, 0.1, 0.5, 1.0, 5.0, 30.0)
+
+
+class MetricsRegistry:
+    """Thread-safe holder of the server's metrics."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._tool_calls: Dict[Tuple[str, str], int] = {}
+        self._requests: Dict[str, int] = {}
+        self._bucket_counts: list[int] = [0] * (len(BUCKETS) + 1)
+        self._duration_sum = 0.0
+        self._duration_count = 0
+        self._gauges: Dict[str, Callable[[], Optional[float]]] = {}
+        self._info_version: Optional[str] = None
+
+    def record_tool_call(self, tool: str, seconds: float, ok: bool) -> None:
+        status = "ok" if ok else "error"
+        with self._lock:
+            key = (tool, status)
+            self._tool_calls[key] = self._tool_calls.get(key, 0) + 1
+            for i, bound in enumerate(BUCKETS):
+                if seconds <= bound:
+                    self._bucket_counts[i] += 1
+                    break
+            else:
+                self._bucket_counts[-1] += 1
+            self._duration_sum += seconds
+            self._duration_count += 1
+
+    def record_request(self, method: str) -> None:
+        with self._lock:
+            self._requests[method] = self._requests.get(method, 0) + 1
+
+    def set_gauge_callable(self, name: str, fn: Callable[[], Optional[float]]) -> None:
+        """Register a gauge evaluated at scrape time; returning None omits it."""
+        with self._lock:
+            self._gauges[name] = fn
+
+    def set_info(self, version: str) -> None:
+        with self._lock:
+            self._info_version = version
+
+    def reset(self) -> None:
+        with self._lock:
+            self._tool_calls.clear()
+            self._requests.clear()
+            self._bucket_counts = [0] * (len(BUCKETS) + 1)
+            self._duration_sum = 0.0
+            self._duration_count = 0
+            self._gauges.clear()
+            self._info_version = None
+
+    def snapshot(self) -> Dict[str, Any]:
+        """A consistent copy of the counting state for rendering."""
+        with self._lock:
+            return {
+                "tool_calls": dict(self._tool_calls),
+                "requests": dict(self._requests),
+                "buckets": list(self._bucket_counts),
+                "duration_sum": self._duration_sum,
+                "duration_count": self._duration_count,
+                "gauges": dict(self._gauges),
+                "info_version": self._info_version,
+            }
+
+
+def _fmt(value: float) -> str:
+    """Render a number the Prometheus way: integers without a decimal point."""
+    as_int = int(value)
+    return str(as_int) if value == as_int and "e" not in repr(value) else repr(value)
+
+
+def render_prometheus(reg: MetricsRegistry) -> str:
+    """Exposition-format output with stable ordering."""
+    snap = reg.snapshot()
+    lines: list[str] = []
+
+    lines.append("# TYPE laravel_mcp_tool_calls_total counter")
+    for (tool, status), count in sorted(snap["tool_calls"].items()):
+        lines.append(
+            f'laravel_mcp_tool_calls_total{{status="{status}",tool="{tool}"}} {count}'
+        )
+
+    lines.append("# TYPE laravel_mcp_requests_total counter")
+    for method, count in sorted(snap["requests"].items()):
+        lines.append(f'laravel_mcp_requests_total{{method="{method}"}} {count}')
+
+    lines.append("# TYPE laravel_mcp_tool_call_seconds histogram")
+    cumulative = 0
+    for bound, bucket_count in zip(BUCKETS, snap["buckets"]):
+        cumulative += bucket_count
+        lines.append(
+            f'laravel_mcp_tool_call_seconds_bucket{{le="{_fmt(bound)}"}} {cumulative}'
+        )
+    cumulative += snap["buckets"][-1]
+    lines.append(f'laravel_mcp_tool_call_seconds_bucket{{le="+Inf"}} {cumulative}')
+    lines.append(f"laravel_mcp_tool_call_seconds_sum {round(snap['duration_sum'], 6)}")
+    lines.append(f"laravel_mcp_tool_call_seconds_count {snap['duration_count']}")
+
+    for name, fn in sorted(snap["gauges"].items()):
+        try:
+            value = fn()
+        except Exception:
+            value = None
+        if value is not None:
+            lines.append(f"# TYPE {name} gauge")
+            lines.append(f"{name} {value}")
+
+    if snap["info_version"] is not None:
+        lines.append("# TYPE laravel_mcp_info gauge")
+        lines.append(f'laravel_mcp_info{{version="{snap["info_version"]}"}} 1')
+
+    return "\n".join(lines) + "\n"
+
+
+# Module singleton: one process, one registry, mirroring the cache singletons
+# in mcp_tools. Tests isolate through reset().
+registry = MetricsRegistry()
+
+
+class MetricsMiddleware(Middleware):
+    """Counts and times every tool call at the protocol layer."""
+
+    async def on_request(self, context, call_next):
+        registry.record_request(context.method)
+        return await call_next(context)
+
+    async def on_call_tool(self, context, call_next):
+        started = time.perf_counter()
+        try:
+            result = await call_next(context)
+        except Exception:
+            registry.record_tool_call(
+                context.message.name, time.perf_counter() - started, ok=False
+            )
+            raise
+        registry.record_tool_call(
+            context.message.name, time.perf_counter() - started, ok=True
+        )
+        return result

--- a/tests/e2e/test_http.py
+++ b/tests/e2e/test_http.py
@@ -46,6 +46,29 @@ class TestHttpTransport:
             )
             assert res.status_code == 421
 
+    async def test_health_and_metrics_operational(self, http_server):
+        base = http_server("--transform-mode", "none")
+        async with httpx.AsyncClient() as plain:
+            health = await plain.get(f"{base}/healthz")
+            assert health.status_code == 200
+            body = health.json()
+            assert body["status"] in ("ok", "degraded")
+            assert body["version"] == laravel_mcp_companion.SERVER_VERSION
+            assert body["docs"]["versions_available"] >= 1
+
+        # Generate one tool call, then confirm it shows up in the scrape.
+        async with Client(StreamableHttpTransport(f"{base}/mcp/")) as client:
+            await client.call_tool("laravel_docs_info", {"version": "12.x"})
+
+        async with httpx.AsyncClient() as plain:
+            scrape = await plain.get(f"{base}/metrics")
+            assert scrape.status_code == 200
+            assert (
+                'laravel_mcp_tool_calls_total{status="ok",tool="laravel_docs_info"} 1'
+                in scrape.text
+            )
+            assert "laravel_mcp_uptime_seconds" in scrape.text
+
     async def test_auth_enforced_end_to_end(self, http_server):
         base = http_server(env_extra={"AUTH_STATIC_TOKENS": "e2e-token:e2e-client"})
         async with httpx.AsyncClient() as bare:

--- a/tests/unit/test_health_metrics.py
+++ b/tests/unit/test_health_metrics.py
@@ -1,0 +1,144 @@
+"""/healthz and /metrics wiring on the HTTP app.
+
+Health is always public (load balancers can't do OAuth); metrics follow the
+bearer-token provider when one is configured. Both are custom routes, which
+bypass FastMCP's auth middleware, so /metrics enforces its own check via the
+same TokenVerifier the MCP endpoint uses.
+"""
+
+import argparse
+
+import httpx
+import pytest
+
+import laravel_mcp_companion
+import metrics
+from laravel_mcp_companion import build_auth_provider, build_http_app, create_mcp_server
+
+
+@pytest.fixture(autouse=True)
+def fresh_registry():
+    metrics.registry.reset()
+    yield
+    metrics.registry.reset()
+
+
+def make_args(**overrides):
+    defaults = {
+        "transport": "http", "host": None, "port": None,
+        "cors_origin": [], "allowed_host": [],
+        "auth_jwks_uri": None, "auth_issuer": None, "auth_audience": None,
+        "auth_required_scope": [],
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def app_for(server):
+    app, _, _ = build_http_app(make_args(), server)
+    return app
+
+
+def client_for(app):
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://localhost",
+        follow_redirects=True,
+    )
+
+
+@pytest.fixture
+def mcp_server(test_docs_dir):
+    return create_mcp_server("TestServer", test_docs_dir, "12.x", transform_mode=None)
+
+
+@pytest.fixture
+def authed_server(test_docs_dir, monkeypatch):
+    monkeypatch.setenv("AUTH_STATIC_TOKENS", "sekrit:client-a")
+    provider = build_auth_provider(make_args())
+    return create_mcp_server(
+        "TestServer", test_docs_dir, "12.x", transform_mode=None, auth=provider
+    )
+
+
+class TestHealthz:
+    async def test_healthy_corpus_reports_ok(self, mcp_server):
+        async with client_for(app_for(mcp_server)) as client:
+            res = await client.get("/healthz")
+            assert res.status_code == 200
+            data = res.json()
+            assert data["status"] in ("ok", "degraded")  # staleness depends on fixture dates
+            assert data["version"] == laravel_mcp_companion.SERVER_VERSION
+            assert data["uptime_seconds"] > 0
+            assert data["docs"]["versions_available"] >= 2
+            assert isinstance(data["docs"]["stale"], bool)
+
+    async def test_stale_corpus_reports_degraded_but_200(self, mcp_server, monkeypatch):
+        monkeypatch.setattr(laravel_mcp_companion, "copy_is_stale", lambda p: True)
+        async with client_for(app_for(mcp_server)) as client:
+            res = await client.get("/healthz")
+            assert res.status_code == 200
+            data = res.json()
+            assert data["status"] == "degraded"
+            assert data["docs"]["stale"] is True
+
+    async def test_empty_corpus_reports_unhealthy_503(self, temp_dir):
+        server = create_mcp_server("TestServer", temp_dir, "12.x", transform_mode=None)
+        async with client_for(app_for(server)) as client:
+            res = await client.get("/healthz")
+            assert res.status_code == 503
+            assert res.json()["status"] == "unhealthy"
+
+    async def test_healthz_public_even_with_auth(self, authed_server):
+        async with client_for(app_for(authed_server)) as client:
+            res = await client.get("/healthz")
+            assert res.status_code == 200
+
+
+class TestMetricsEndpoint:
+    async def test_public_when_no_auth_configured(self, mcp_server):
+        async with client_for(app_for(mcp_server)) as client:
+            res = await client.get("/metrics")
+            assert res.status_code == 200
+            assert res.headers["content-type"].startswith("text/plain")
+            assert "# TYPE laravel_mcp_tool_calls_total counter" in res.text
+            version = laravel_mcp_companion.SERVER_VERSION
+            assert f'laravel_mcp_info{{version="{version}"}} 1' in res.text
+            assert "laravel_mcp_uptime_seconds" in res.text
+
+    async def test_requires_token_when_auth_configured(self, authed_server):
+        async with client_for(app_for(authed_server)) as client:
+            bare = await client.get("/metrics")
+            assert bare.status_code == 401
+            assert bare.headers.get("www-authenticate", "").startswith("Bearer")
+
+            wrong = await client.get(
+                "/metrics", headers={"authorization": "Bearer nope"}
+            )
+            assert wrong.status_code == 401
+
+            good = await client.get(
+                "/metrics", headers={"authorization": "Bearer sekrit"}
+            )
+            assert good.status_code == 200
+            assert "laravel_mcp_info" in good.text
+
+    async def test_tool_calls_flow_into_metrics(self, mcp_server):
+        from fastmcp import Client
+
+        async with Client(mcp_server) as mcp_client:
+            await mcp_client.call_tool("laravel_docs_info", {"version": "12.x"})
+
+        async with client_for(app_for(mcp_server)) as client:
+            res = await client.get("/metrics")
+            assert (
+                'laravel_mcp_tool_calls_total{status="ok",tool="laravel_docs_info"} 1'
+                in res.text
+            )
+            assert 'laravel_mcp_requests_total{method="tools/call"} 1' in res.text
+
+    async def test_docs_age_gauge_present_for_dated_corpus(self, mcp_server):
+        async with client_for(app_for(mcp_server)) as client:
+            res = await client.get("/metrics")
+            # fixture corpus carries commit dates, so the age gauge renders
+            assert "laravel_mcp_docs_copy_age_days" in res.text

--- a/tests/unit/test_health_metrics.py
+++ b/tests/unit/test_health_metrics.py
@@ -87,7 +87,15 @@ class TestHealthz:
         async with client_for(app_for(server)) as client:
             res = await client.get("/healthz")
             assert res.status_code == 503
-            assert res.json()["status"] == "unhealthy"
+            data = res.json()
+            assert data["status"] == "unhealthy"
+            # numeric-or-null contract: monitors parse this as a number
+            assert data["docs"]["copy_age_days"] is None
+
+    async def test_copy_age_days_is_numeric_when_known(self, mcp_server):
+        async with client_for(app_for(mcp_server)) as client:
+            data = (await client.get("/healthz")).json()
+            assert isinstance(data["docs"]["copy_age_days"], (int, float))
 
     async def test_healthz_public_even_with_auth(self, authed_server):
         async with client_for(app_for(authed_server)) as client:
@@ -122,6 +130,31 @@ class TestMetricsEndpoint:
             )
             assert good.status_code == 200
             assert "laravel_mcp_info" in good.text
+
+    async def test_verifier_outage_fails_closed_not_500(self, test_docs_dir, monkeypatch):
+        """A JWKS fetch failure raises out of JWTVerifier (network errors
+        aren't in its catch list), and FastMCP's auth middleware eagerly
+        verifies ANY request carrying an Authorization header — every route,
+        custom ones included — so an unhandled raise is an app-wide 500.
+        harden_verifier fails closed instead: token-bearing requests get 401
+        during the outage, and the public routes keep answering."""
+        monkeypatch.setenv("AUTH_STATIC_TOKENS", "sekrit:client-a")
+        provider = build_auth_provider(make_args())
+
+        async def explode(token):
+            raise ValueError("JWKS failed to fetch")
+
+        monkeypatch.setattr(provider, "verify_token", explode)
+        laravel_mcp_companion.harden_verifier(provider)
+        server = create_mcp_server(
+            "TestServer", test_docs_dir, "12.x", transform_mode=None, auth=provider
+        )
+        async with client_for(app_for(server)) as client:
+            res = await client.get("/metrics", headers={"authorization": "Bearer sekrit"})
+            assert res.status_code == 401  # failed closed, not 500
+
+            health = await client.get("/healthz")
+            assert health.status_code == 200  # public routes unaffected
 
     async def test_tool_calls_flow_into_metrics(self, mcp_server):
         from fastmcp import Client

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,0 +1,120 @@
+"""metrics.py: registry counting, histogram bucketing, Prometheus rendering,
+and the FastMCP middleware that feeds them."""
+
+import pytest
+
+import metrics
+from metrics import MetricsMiddleware, MetricsRegistry, render_prometheus
+
+
+@pytest.fixture(autouse=True)
+def fresh_registry():
+    metrics.registry.reset()
+    yield
+    metrics.registry.reset()
+
+
+class TestRegistry:
+    def test_tool_calls_count_by_tool_and_status(self):
+        r = MetricsRegistry()
+        r.record_tool_call("search_laravel_docs", 0.05, ok=True)
+        r.record_tool_call("search_laravel_docs", 0.07, ok=True)
+        r.record_tool_call("search_laravel_docs", 0.01, ok=False)
+        out = render_prometheus(r)
+        assert 'laravel_mcp_tool_calls_total{status="ok",tool="search_laravel_docs"} 2' in out
+        assert 'laravel_mcp_tool_calls_total{status="error",tool="search_laravel_docs"} 1' in out
+
+    def test_requests_count_by_method(self):
+        r = MetricsRegistry()
+        r.record_request("tools/call")
+        r.record_request("tools/call")
+        r.record_request("initialize")
+        out = render_prometheus(r)
+        assert 'laravel_mcp_requests_total{method="tools/call"} 2' in out
+        assert 'laravel_mcp_requests_total{method="initialize"} 1' in out
+
+    def test_histogram_buckets_are_cumulative_and_consistent(self):
+        r = MetricsRegistry()
+        r.record_tool_call("t", 0.004, ok=True)   # -> 0.005 bucket
+        r.record_tool_call("t", 0.5, ok=True)     # boundary lands in le=0.5
+        r.record_tool_call("t", 40.0, ok=True)    # only +Inf
+        out = render_prometheus(r)
+        assert 'laravel_mcp_tool_call_seconds_bucket{le="0.005"} 1' in out
+        assert 'laravel_mcp_tool_call_seconds_bucket{le="0.5"} 2' in out
+        assert 'laravel_mcp_tool_call_seconds_bucket{le="30"} 2' in out
+        assert 'laravel_mcp_tool_call_seconds_bucket{le="+Inf"} 3' in out
+        assert 'laravel_mcp_tool_call_seconds_count 3' in out
+        assert "laravel_mcp_tool_call_seconds_sum 40.504" in out
+
+    def test_gauge_callables_render_at_scrape_time(self):
+        r = MetricsRegistry()
+        value = {"v": 1.0}
+        r.set_gauge_callable("laravel_mcp_uptime_seconds", lambda: value["v"])
+        assert "laravel_mcp_uptime_seconds 1.0" in render_prometheus(r)
+        value["v"] = 2.5
+        assert "laravel_mcp_uptime_seconds 2.5" in render_prometheus(r)
+
+    def test_none_gauge_is_omitted(self):
+        r = MetricsRegistry()
+        r.set_gauge_callable("laravel_mcp_docs_copy_age_days", lambda: None)
+        assert "laravel_mcp_docs_copy_age_days" not in render_prometheus(r)
+
+    def test_info_metric(self):
+        r = MetricsRegistry()
+        r.set_info("0.12.0")
+        assert 'laravel_mcp_info{version="0.12.0"} 1' in render_prometheus(r)
+
+    def test_type_lines_present(self):
+        r = MetricsRegistry()
+        r.record_tool_call("t", 0.1, ok=True)
+        r.record_request("initialize")
+        out = render_prometheus(r)
+        assert "# TYPE laravel_mcp_tool_calls_total counter" in out
+        assert "# TYPE laravel_mcp_requests_total counter" in out
+        assert "# TYPE laravel_mcp_tool_call_seconds histogram" in out
+
+    def test_reset_empties_everything(self):
+        r = MetricsRegistry()
+        r.record_tool_call("t", 0.1, ok=True)
+        r.record_request("x")
+        r.reset()
+        out = render_prometheus(r)
+        assert "tool_calls_total{" not in out
+        assert "requests_total{" not in out
+
+    def test_render_is_deterministic(self):
+        r = MetricsRegistry()
+        r.record_tool_call("b_tool", 0.1, ok=True)
+        r.record_tool_call("a_tool", 0.1, ok=False)
+        r.record_request("z")
+        r.record_request("a")
+        assert render_prometheus(r) == render_prometheus(r)
+        # sorted label values: a_tool line appears before b_tool
+        out = render_prometheus(r)
+        assert out.index("a_tool") < out.index("b_tool")
+
+
+class TestMiddleware:
+    async def test_tool_calls_recorded_through_a_live_server(self):
+        from fastmcp import Client, FastMCP
+
+        server = FastMCP("t", middleware=[MetricsMiddleware()])
+
+        @server.tool
+        def works() -> str:
+            return "ok"
+
+        @server.tool
+        def explodes() -> str:
+            raise ValueError("boom")
+
+        async with Client(server) as client:
+            await client.call_tool("works", {})
+            result = await client.call_tool("explodes", {}, raise_on_error=False)
+            assert result.is_error
+
+        out = render_prometheus(metrics.registry)
+        assert 'laravel_mcp_tool_calls_total{status="ok",tool="works"} 1' in out
+        assert 'laravel_mcp_tool_calls_total{status="error",tool="explodes"} 1' in out
+        assert 'laravel_mcp_requests_total{method="tools/call"} 2' in out
+        assert "laravel_mcp_tool_call_seconds_count 2" in out


### PR DESCRIPTION
Second v0.13.0 sub-project (spec and plan in `docs/superpowers/`): operational endpoints for HTTP deployments.

- **`GET /healthz`** — always-public liveness/readiness JSON. `ok`/`degraded` both 200 (degraded reuses the v0.11.0 staleness rule: corpus is behind, pull a newer image); 503 only when no documentation is readable at all.
- **`GET /metrics`** — hand-rolled Prometheus text format, zero new dependencies: `laravel_mcp_tool_calls_total{tool,status}`, one overall latency histogram (per-tool histograms would be 26× the cardinality for little signal), `laravel_mcp_requests_total{method}`, uptime and docs-age gauges, `laravel_mcp_info{version}`. Public on unauthenticated deployments; requires a valid bearer token whenever an auth provider is configured — validated through the same `TokenVerifier` as the MCP endpoint, since custom routes bypass FastMCP's auth middleware.
- **Collection** via FastMCP middleware (`on_call_tool`/`on_request`): every tool call counted and timed at the protocol layer, zero changes to the 26 tool closures, identical under stdio (where there's simply no endpoint to read it).

Tests: 10 unit tests for the registry/renderer/middleware (golden-matched exposition output), 8 wiring tests (health states incl. degraded/503, metrics 401/200 with auth, counters flowing end to end), one e2e test against the real server. 838 + 8 e2e green, coverage 81.1% (gate 80), ruff/mypy clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/healthz` for HTTP service health and documentation availability checks.
  * Added Prometheus-compatible `/metrics` reporting for requests, tool calls, latency, uptime, and documentation age.
  * Metrics access respects configured bearer-token authentication.

* **Documentation**
  * Documented operational endpoints and marked health monitoring and metrics as completed.

* **Tests**
  * Expanded coverage for health checks, metrics, authentication, discovery, search flows, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->