### PR TITLE
v0.13.0: rate limiting, degradation pins, latency benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ docs-only commit and contains no code change.
 ## [Unreleased]
 
 ### Added
+- Opt-in rate limiting for the HTTP transport: `--rate-limit RPS` /
+  `RATE_LIMIT_RPS` with a burst knob defaulting to `max(10, 2×RPS)` — the
+  limiter counts the MCP handshake against the bucket, so small bursts
+  self-throttle. One global token bucket, documented as a throughput cap
+  rather than per-client fairness. Off unless configured.
+- Report-only latency benchmarks (`pytest -m bench`) against the real
+  corpus, printing p50/p95 per operation against the v1.0.0 sub-100ms
+  target. First measurements: warm search p95 ~4ms, section reads ~1.4ms.
+- Tests pinning graceful-degradation behavior that previously rested on
+  luck: search surviving hostile bytes in a corpus file, and throttled
+  clients recovering cleanly when the bucket refills.
 - Operational endpoints for the HTTP transport: `GET /healthz` (public
   liveness/readiness JSON — `degraded` flags a stale corpus at 200, 503 is
   reserved for no readable documentation) and `GET /metrics` (Prometheus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@ docs-only commit and contains no code change.
 ## [Unreleased]
 
 ### Added
-- Opt-in rate limiting for the HTTP transport: `--rate-limit RPS` /
+- Opt-in rate limiting for the HTTP transport's MCP surface (operational
+  endpoints stay unlimited — throttling health checks marks healthy
+  instances down): `--rate-limit RPS` /
   `RATE_LIMIT_RPS` with a burst knob defaulting to `max(10, 2×RPS)` — the
   limiter counts the MCP handshake against the bucket, so small bursts
   self-throttle. One global token bucket, documented as a throughput cap

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ docker run --rm -i ghcr.io/brianirish/laravel-mcp-companion:latest --force-updat
 | `--auth-issuer ISSUER` | Required token issuer, with `--auth-jwks-uri` (env: `AUTH_ISSUER`) | none |
 | `--auth-audience AUD` | Required token audience, with `--auth-jwks-uri` (env: `AUTH_AUDIENCE`) | none |
 | `--auth-required-scope SCOPE` | Scope every token must carry, repeatable (env: `AUTH_REQUIRED_SCOPES`) | none |
+| `--rate-limit RPS` | Requests/second accepted across the whole server in HTTP mode (env: `RATE_LIMIT_RPS`) | none (no limiting) |
+| `--rate-limit-burst N` | Token-bucket burst capacity (env: `RATE_LIMIT_BURST`) | `max(10, 2×RPS)` |
 
 ### Keeping documentation current
 
@@ -214,6 +216,16 @@ python laravel_mcp_companion.py --transport http \
 ```
 
 Requests with an unrecognized `Host` get `421`; requests from an unlisted `Origin` get `403`. Passing `--allowed-host` or `--cors-origin` on the command line replaces the corresponding environment variable rather than adding to it. If you expose this beyond localhost, put an authenticating reverse proxy in front of it. Avoid `--transform-mode code` over HTTP entirely — `execute` is a code execution endpoint.
+
+### Rate limiting (HTTP mode)
+
+Off by default. `--rate-limit 20` caps the server at 20 requests/second with a
+single **global** token bucket — a total throughput cap, not per-client
+fairness (without auth there is no reliable client identity to key on). The
+limit counts every MCP request including the initialize handshake, which is
+why the burst default stays at `max(10, 2×RPS)`; keep the burst comfortably
+above your clients' handshake size if you lower it. Throttled requests
+receive a clean MCP error and succeed again once the bucket refills.
 
 ### Operational endpoints (HTTP mode)
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ docker run --rm -i ghcr.io/brianirish/laravel-mcp-companion:latest --force-updat
 | `--auth-issuer ISSUER` | Required token issuer, with `--auth-jwks-uri` (env: `AUTH_ISSUER`) | none |
 | `--auth-audience AUD` | Required token audience, with `--auth-jwks-uri` (env: `AUTH_AUDIENCE`) | none |
 | `--auth-required-scope SCOPE` | Scope every token must carry, repeatable (env: `AUTH_REQUIRED_SCOPES`) | none |
-| `--rate-limit RPS` | Requests/second accepted across the whole server in HTTP mode (env: `RATE_LIMIT_RPS`) | none (no limiting) |
+| `--rate-limit RPS` | MCP requests/second accepted in HTTP mode; operational endpoints are never limited (env: `RATE_LIMIT_RPS`) | none (no limiting) |
 | `--rate-limit-burst N` | Token-bucket burst capacity (env: `RATE_LIMIT_BURST`) | `max(10, 2×RPS)` |
 
 ### Keeping documentation current
@@ -219,13 +219,17 @@ Requests with an unrecognized `Host` get `421`; requests from an unlisted `Origi
 
 ### Rate limiting (HTTP mode)
 
-Off by default. `--rate-limit 20` caps the server at 20 requests/second with a
-single **global** token bucket — a total throughput cap, not per-client
-fairness (without auth there is no reliable client identity to key on). The
-limit counts every MCP request including the initialize handshake, which is
-why the burst default stays at `max(10, 2×RPS)`; keep the burst comfortably
-above your clients' handshake size if you lower it. Throttled requests
-receive a clean MCP error and succeed again once the bucket refills.
+Off by default. `--rate-limit 20` caps **MCP requests** — tool calls,
+searches, the protocol surface — at 20/second with a single global token
+bucket: a total throughput cap, not per-client fairness (without auth there
+is no reliable client identity to key on). The operational endpoints
+(`/healthz`, `/metrics`, `/.well-known/...`) are deliberately outside the
+limit: throttling a load balancer's health checks marks healthy instances
+down, and those handlers are trivial reads. The limit counts every MCP
+request including the initialize handshake, which is why the burst default
+stays at `max(10, 2×RPS)`; keep the burst comfortably above your clients'
+handshake size if you lower it. Throttled requests receive a clean MCP error
+and succeed again once the bucket refills.
 
 ### Operational endpoints (HTTP mode)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -163,8 +163,11 @@ retrieval overhaul in v0.11.0 already delivered the highest-value part.
 
 ### Reliability & Monitoring
 - [x] Health monitoring and metrics endpoints *(/healthz + Prometheus /metrics, HTTP mode)*
-- [ ] Rate limiting and quota management
-- [ ] Error recovery and graceful degradation improvements
+- [x] Rate limiting *(opt-in global token bucket via `--rate-limit`; quota
+  management deliberately out of scope — no per-client identity without auth)*
+- [x] Error recovery and graceful degradation *(accumulated and now pinned by
+  tests: partial update results, discovery fallback, fail-closed caches and
+  token verification, corrupt-corpus search resilience, staleness advice)*
 - [x] Performance optimization and caching improvements *(delivered in v0.10.0)*
 
 ### Security & Stability
@@ -177,7 +180,8 @@ retrieval overhaul in v0.11.0 already delivered the highest-value part.
 ### Quality Assurance
 - [x] 80%+ coverage of product code *(81% as of the v0.13.0 coverage push; gate ratcheted to 80)*
 - [x] Integration tests through a real MCP client *(e2e suite over stdio and HTTP; also a v1.0.0 criterion)*
-- [ ] Load testing and performance benchmarks
+- [x] Latency benchmarks *(report-only `pytest -m bench` against the real
+  corpus; warm search p95 ~4ms against the v1.0.0 100ms target)*
 - [ ] Documentation completeness audit
 
 ---

--- a/laravel_mcp_companion.py
+++ b/laravel_mcp_companion.py
@@ -7,6 +7,7 @@ It allows AI assistants and other tools to access and search Laravel documentati
 recommend appropriate Laravel packages for specific use cases.
 """
 
+import math
 import os
 import sys
 import logging
@@ -14,7 +15,10 @@ import re
 import argparse
 import json
 from pathlib import Path
-from typing import Dict, Optional, List, Any
+from typing import Dict, Optional, List, Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from fastmcp.server.middleware.rate_limiting import RateLimitingMiddleware
 import threading
 import anyio.to_thread
 from fastmcp import Context, FastMCP
@@ -791,6 +795,22 @@ def parse_arguments():
              "AUTH_REQUIRED_SCOPES when given (env: AUTH_REQUIRED_SCOPES, comma-separated)"
     )
     parser.add_argument(
+        "--rate-limit",
+        type=float,
+        default=None,
+        metavar="RPS",
+        help="Requests per second accepted across the whole server in HTTP mode; "
+             "unset means no limiting (env: RATE_LIMIT_RPS)"
+    )
+    parser.add_argument(
+        "--rate-limit-burst",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Token-bucket burst capacity; defaults to max(10, 2*RPS) so the MCP "
+             "handshake never self-throttles (env: RATE_LIMIT_BURST)"
+    )
+    parser.add_argument(
         "--transform-mode",
         type=str,
         default=os.environ.get("TRANSFORM_MODE", "").lower() or None,
@@ -819,6 +839,18 @@ def parse_arguments():
         args.allowed_host = _split_env_list("ALLOWED_HOSTS") or []
     if args.auth_required_scope is None:
         args.auth_required_scope = _split_env_list("AUTH_REQUIRED_SCOPES") or []
+
+    # argparse type= does not run on defaults, so env fallbacks parse here.
+    if args.rate_limit is None and os.environ.get("RATE_LIMIT_RPS"):
+        try:
+            args.rate_limit = float(os.environ["RATE_LIMIT_RPS"])
+        except ValueError:
+            parser.error(f"invalid RATE_LIMIT_RPS: {os.environ['RATE_LIMIT_RPS']!r}")
+    if args.rate_limit_burst is None and os.environ.get("RATE_LIMIT_BURST"):
+        try:
+            args.rate_limit_burst = int(os.environ["RATE_LIMIT_BURST"])
+        except ValueError:
+            parser.error(f"invalid RATE_LIMIT_BURST: {os.environ['RATE_LIMIT_BURST']!r}")
 
     # Allowed hosts are matched with fnmatch, so a pattern entry would match
     # every Host header and silently disable the guard while still looking like
@@ -1360,6 +1392,46 @@ def fuzzy_search(query: str, text: str, threshold: float = 0.6) -> List[Dict]:
                 })
     
     return sorted(matches, key=lambda x: x['score'], reverse=True)
+
+
+def build_rate_limiter(args) -> Optional["RateLimitingMiddleware"]:
+    """Build the opt-in token-bucket limiter from CLI/env configuration.
+
+    One global bucket for the whole server — a total-throughput cap, not
+    per-client fairness; without auth there is no reliable client identity
+    to key on. The limiter counts every MCP request including the initialize
+    handshake, so the burst default stays comfortably above handshake size.
+
+    Returns None when unset, or when the transport is stdio, where a single
+    local client throttling itself serves nobody.
+    """
+    if args.rate_limit is None:
+        return None
+
+    if args.transport != "http":
+        logger.warning(
+            "A rate limit is configured but the transport is stdio; ignoring it. "
+            "Rate limiting only applies to the HTTP transport."
+        )
+        return None
+
+    if args.rate_limit <= 0:
+        logger.error(f"--rate-limit must be positive, got {args.rate_limit}")
+        sys.exit(1)
+
+    burst = args.rate_limit_burst
+    if burst is None:
+        burst = max(10, math.ceil(2 * args.rate_limit))
+    elif burst < 1:
+        logger.error(f"--rate-limit-burst must be at least 1, got {burst}")
+        sys.exit(1)
+
+    from fastmcp.server.middleware.rate_limiting import RateLimitingMiddleware
+    logger.info(f"Rate limiting enabled: {args.rate_limit} req/s, burst {burst}")
+    return RateLimitingMiddleware(
+        max_requests_per_second=args.rate_limit,
+        burst_capacity=burst,
+    )
 
 
 def harden_verifier(verifier: "TokenVerifier") -> "TokenVerifier":

--- a/laravel_mcp_companion.py
+++ b/laravel_mcp_companion.py
@@ -1555,7 +1555,7 @@ def _server_icon() -> "Icon":
     return Icon(src=f"data:image/svg+xml;base64,{encoded}", mimeType="image/svg+xml")
 
 
-def create_mcp_server(server_name: str, docs_path: Path, runtime_version: str, transform_mode: Optional[str] = "search", auth: Optional["TokenVerifier"] = None) -> FastMCP:
+def create_mcp_server(server_name: str, docs_path: Path, runtime_version: str, transform_mode: Optional[str] = "search", auth: Optional["TokenVerifier"] = None, rate_limiter: Optional["RateLimitingMiddleware"] = None) -> FastMCP:
     """Create and configure the MCP server with all tools and resources.
 
     Args:
@@ -1597,7 +1597,11 @@ def create_mcp_server(server_name: str, docs_path: Path, runtime_version: str, t
 
     # Metrics collection is always on (negligible overhead: one lock and a
     # clock read per call) so the HTTP endpoints never lie about "since when".
+    # Registered before the rate limiter so throttled requests still count —
+    # the ordering contract is pinned by test, not assumed from upstream docs.
     mcp.add_middleware(MetricsMiddleware())
+    if rate_limiter is not None:
+        mcp.add_middleware(rate_limiter)
     start_time = time.monotonic()
     metrics_registry.set_info(SERVER_VERSION)
     metrics_registry.set_gauge_callable(
@@ -2756,7 +2760,8 @@ def main():
     mcp = create_mcp_server(
         args.server_name, docs_path, args.version,
         transform_mode=None if mode == "none" else mode,
-        auth=build_auth_provider(args)
+        auth=build_auth_provider(args),
+        rate_limiter=build_rate_limiter(args)
     )
 
     # Log server startup

--- a/laravel_mcp_companion.py
+++ b/laravel_mcp_companion.py
@@ -799,8 +799,8 @@ def parse_arguments():
         type=float,
         default=None,
         metavar="RPS",
-        help="Requests per second accepted across the whole server in HTTP mode; "
-             "unset means no limiting (env: RATE_LIMIT_RPS)"
+        help="MCP requests per second accepted in HTTP mode (operational endpoints "
+             "like /healthz are never limited); unset means no limiting (env: RATE_LIMIT_RPS)"
     )
     parser.add_argument(
         "--rate-limit-burst",
@@ -1415,8 +1415,11 @@ def build_rate_limiter(args) -> Optional["RateLimitingMiddleware"]:
         )
         return None
 
-    if args.rate_limit <= 0:
-        logger.error(f"--rate-limit must be positive, got {args.rate_limit}")
+    # nan/inf pass a <=0 comparison and float() parses both from env, so a
+    # finiteness check is what stands between a config typo and either an
+    # uncontrolled math.ceil traceback or a bucket with infinite capacity.
+    if not math.isfinite(args.rate_limit) or args.rate_limit <= 0:
+        logger.error(f"--rate-limit must be a positive finite number, got {args.rate_limit}")
         sys.exit(1)
 
     burst = args.rate_limit_burst

--- a/pytest.ini
+++ b/pytest.ini
@@ -19,7 +19,7 @@ addopts =
 ;   e2e tests spawn the real server as a subprocess; they run explicitly via
 ;   `pytest -m e2e --no-cov` (the CLI -m overrides this one) and as their own
 ;   CI step, so a wedged subprocess cannot mask the unit suite.
-    -m "not e2e"
+    -m "not e2e and not bench"
 testpaths = tests
 python_files = test_*.py
 python_classes = Test*
@@ -32,6 +32,7 @@ markers =
     external: marks tests that interact with external services
     protocol: marks tests as MCP protocol compliance tests
     e2e: end-to-end tests through real transports (run with -m e2e --no-cov)
+    bench: report-only latency benchmarks against the real corpus (run with -m bench --no-cov -s)
 filterwarnings =
     ignore::DeprecationWarning
     ignore::PendingDeprecationWarning

--- a/tests/bench/__init__.py
+++ b/tests/bench/__init__.py
@@ -1,0 +1,3 @@
+# Report-only latency benchmarks. Timing is printed, never asserted:
+# the sub-100ms target is v1.0.0's gate decision, and latency assertions
+# on shared CI runners are flake factories.

--- a/tests/bench/test_latency.py
+++ b/tests/bench/test_latency.py
@@ -1,0 +1,110 @@
+"""Latency benchmarks over the real documentation corpus.
+
+Run: uv run pytest -m bench --no-cov -s -q
+
+Uses the repo's own docs/ tree (present after any docs sync) through the
+in-memory client — no subprocess, no network. Assertions cover setup
+correctness only; timing is reported against the v1.0.0 sub-100ms target.
+"""
+
+import statistics
+import time
+from pathlib import Path
+
+import pytest
+
+from fastmcp import Client
+
+from laravel_mcp_companion import create_mcp_server
+
+pytestmark = pytest.mark.bench
+
+REPO_DOCS = Path(__file__).resolve().parents[2] / "docs"
+TARGET_MS = 100.0
+
+QUERIES = [
+    "routing",
+    "queue retry failed jobs",
+    "eloquent relationships",
+    "middleware",
+    "validation rules",
+    "cache tags",
+    "broadcasting events",
+    "sanctum api tokens",
+    "blade components",
+    "queue:retry",
+]
+
+
+@pytest.fixture(scope="module")
+def corpus_server():
+    if not (REPO_DOCS / "12.x").is_dir():
+        pytest.skip("real corpus absent (docs/12.x); run a docs sync first")
+    return create_mcp_server("BenchServer", REPO_DOCS, "12.x", transform_mode=None)
+
+
+def report(operation: str, samples_ms: list) -> None:
+    p50 = statistics.median(samples_ms)
+    p95 = statistics.quantiles(samples_ms, n=20)[-1] if len(samples_ms) >= 20 else max(samples_ms)
+    verdict = "within" if p95 <= TARGET_MS else "OVER"
+    print(
+        f"\n  {operation:32s} n={len(samples_ms):3d}  "
+        f"p50={p50:7.1f}ms  p95={p95:7.1f}ms  max={max(samples_ms):7.1f}ms  "
+        f"[{verdict} {TARGET_MS:.0f}ms target]"
+    )
+
+
+class TestSearchLatency:
+    async def test_cold_and_warm_search(self, corpus_server):
+        async with Client(corpus_server) as client:
+            # Cold: first search pays the BM25 index build.
+            started = time.perf_counter()
+            first = await client.call_tool(
+                "search_laravel_docs", {"query": QUERIES[0], "include_external": False}
+            )
+            cold_ms = (time.perf_counter() - started) * 1000
+            assert first.structured_content.get("results"), "cold search returned nothing"
+            print(f"\n  {'search (cold, index build)':32s} n=  1  once={cold_ms:7.1f}ms")
+
+            samples = []
+            for i in range(30):
+                query = QUERIES[i % len(QUERIES)]
+                started = time.perf_counter()
+                result = await client.call_tool(
+                    "search_laravel_docs", {"query": query, "include_external": False}
+                )
+                samples.append((time.perf_counter() - started) * 1000)
+                assert result.structured_content is not None
+            report("search (warm)", samples)
+
+
+class TestReadLatency:
+    async def test_section_read(self, corpus_server):
+        async with Client(corpus_server) as client:
+            hit = (await client.call_tool(
+                "search_laravel_docs", {"query": "queue retry failed jobs", "include_external": False}
+            )).structured_content["results"][0]
+            filename = hit["file"].split("/", 1)[1]
+            section = hit["anchor"] or hit["heading"]
+
+            samples = []
+            for _ in range(30):
+                started = time.perf_counter()
+                result = await client.call_tool(
+                    "read_laravel_doc_section", {"filename": filename, "section": section}
+                )
+                samples.append((time.perf_counter() - started) * 1000)
+                assert not result.is_error
+            report("read_laravel_doc_section", samples)
+
+
+class TestInfoLatency:
+    async def test_docs_info(self, corpus_server):
+        async with Client(corpus_server) as client:
+            samples = []
+            for _ in range(30):
+                started = time.perf_counter()
+                result = await client.call_tool("laravel_docs_info", {"version": "12.x"})
+                samples.append((time.perf_counter() - started) * 1000)
+                assert result.structured_content.get("version") == "12.x"
+            report("laravel_docs_info", samples)

--- a/tests/unit/test_rate_limit_config.py
+++ b/tests/unit/test_rate_limit_config.py
@@ -1,0 +1,87 @@
+"""Rate limit configuration: opt-in, loud on misconfiguration, stdio-inert.
+
+The burst default matters more than it looks: FastMCP's limiter counts the
+MCP initialize handshake against the bucket, so a small burst self-throttles
+before the first tool call ever runs.
+"""
+
+import argparse
+
+import pytest
+
+from laravel_mcp_companion import build_rate_limiter, parse_arguments
+
+
+def make_args(**overrides):
+    defaults = {"transport": "http", "rate_limit": None, "rate_limit_burst": None}
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+class TestBuildRateLimiter:
+    def test_unset_returns_none(self):
+        assert build_rate_limiter(make_args()) is None
+
+    def test_configured_returns_middleware(self):
+        from fastmcp.server.middleware.rate_limiting import RateLimitingMiddleware
+
+        limiter = build_rate_limiter(make_args(rate_limit=5.0))
+        assert isinstance(limiter, RateLimitingMiddleware)
+
+    @pytest.mark.parametrize("rps", [0.0, -1.0])
+    def test_nonpositive_rps_exits(self, rps):
+        with pytest.raises(SystemExit):
+            build_rate_limiter(make_args(rate_limit=rps))
+
+    def test_burst_below_one_exits(self):
+        with pytest.raises(SystemExit):
+            build_rate_limiter(make_args(rate_limit=5.0, rate_limit_burst=0))
+
+    @pytest.mark.parametrize("rps,expected_burst", [(2.0, 10), (20.0, 40), (0.4, 10)])
+    def test_default_burst_covers_the_handshake(self, rps, expected_burst, monkeypatch):
+        captured = {}
+        from fastmcp.server.middleware import rate_limiting
+
+        original = rate_limiting.RateLimitingMiddleware.__init__
+
+        def spy(self, max_requests_per_second, burst_capacity=None, **kwargs):
+            captured["rps"] = max_requests_per_second
+            captured["burst"] = burst_capacity
+            original(self, max_requests_per_second, burst_capacity=burst_capacity, **kwargs)
+
+        monkeypatch.setattr(rate_limiting.RateLimitingMiddleware, "__init__", spy)
+        build_rate_limiter(make_args(rate_limit=rps))
+        assert captured["rps"] == rps
+        assert captured["burst"] == expected_burst
+
+    def test_explicit_burst_honored(self):
+        limiter = build_rate_limiter(make_args(rate_limit=5.0, rate_limit_burst=3))
+        assert limiter is not None
+
+    def test_stdio_warns_and_ignores(self, caplog):
+        result = build_rate_limiter(make_args(transport="stdio", rate_limit=5.0))
+        assert result is None
+        assert any("stdio" in r.message for r in caplog.records)
+
+
+class TestRateLimitArgs:
+    def test_env_fallback_parses_float(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["prog"])
+        monkeypatch.setenv("RATE_LIMIT_RPS", "12.5")
+        monkeypatch.setenv("RATE_LIMIT_BURST", "30")
+        args = parse_arguments()
+        assert args.rate_limit == 12.5
+        assert args.rate_limit_burst == 30
+
+    def test_unset_env_means_none(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["prog"])
+        monkeypatch.delenv("RATE_LIMIT_RPS", raising=False)
+        args = parse_arguments()
+        assert args.rate_limit is None
+        assert args.rate_limit_burst is None
+
+    def test_invalid_env_value_errors(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["prog"])
+        monkeypatch.setenv("RATE_LIMIT_RPS", "lots")
+        with pytest.raises(SystemExit):
+            parse_arguments()

--- a/tests/unit/test_rate_limit_config.py
+++ b/tests/unit/test_rate_limit_config.py
@@ -33,6 +33,18 @@ class TestBuildRateLimiter:
         with pytest.raises(SystemExit):
             build_rate_limiter(make_args(rate_limit=rps))
 
+    @pytest.mark.parametrize("rps", [float("nan"), float("inf")])
+    def test_nonfinite_rps_exits_cleanly(self, rps):
+        """nan/inf pass a <=0 check (neither compares below zero) and float()
+        parses both from env, so a config typo must die loudly here rather
+        than as a math.ceil traceback or an infinite bucket."""
+        with pytest.raises(SystemExit):
+            build_rate_limiter(make_args(rate_limit=rps))
+
+    def test_nonfinite_rps_with_explicit_burst_still_exits(self):
+        with pytest.raises(SystemExit):
+            build_rate_limiter(make_args(rate_limit=float("inf"), rate_limit_burst=10))
+
     def test_burst_below_one_exits(self):
         with pytest.raises(SystemExit):
             build_rate_limiter(make_args(rate_limit=5.0, rate_limit_burst=0))
@@ -85,3 +97,13 @@ class TestRateLimitArgs:
         monkeypatch.setenv("RATE_LIMIT_RPS", "lots")
         with pytest.raises(SystemExit):
             parse_arguments()
+
+    @pytest.mark.parametrize("value", ["inf", "nan", "-inf"])
+    def test_nonfinite_env_value_rejected_at_build(self, monkeypatch, value):
+        """float() happily parses these strings; the builder must not."""
+        monkeypatch.setattr("sys.argv", ["prog"])
+        monkeypatch.setenv("TRANSPORT", "http")
+        monkeypatch.setenv("RATE_LIMIT_RPS", value)
+        args = parse_arguments()
+        with pytest.raises(SystemExit):
+            build_rate_limiter(args)

--- a/tests/unit/test_rate_limiting.py
+++ b/tests/unit/test_rate_limiting.py
@@ -1,0 +1,104 @@
+"""Rate limiting through the live server, plus degradation pins.
+
+The throttle tests use a burst sized so the MCP handshake passes and the
+budget runs out mid-conversation — the realistic failure shape.
+"""
+
+import argparse
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from fastmcp import Client
+
+import metrics
+from laravel_mcp_companion import build_rate_limiter, create_mcp_server
+from mcp_tools import search_laravel_docs_data
+
+
+@pytest.fixture(autouse=True)
+def fresh_registry():
+    metrics.registry.reset()
+    yield
+    metrics.registry.reset()
+
+
+def limiter(rps, burst):
+    args = argparse.Namespace(transport="http", rate_limit=rps, rate_limit_burst=burst)
+    return build_rate_limiter(args)
+
+
+class TestThrottleAndRecover:
+    async def test_budget_exhausts_and_refills(self, test_docs_dir):
+        # burst 8: the handshake (~4 requests) passes, a couple of tool
+        # calls succeed, then the bucket runs dry at 1 rps.
+        server = create_mcp_server(
+            "TestServer", test_docs_dir, "12.x", transform_mode=None,
+            rate_limiter=limiter(1.0, 8),
+        )
+        async with Client(server) as client:
+            saw_limit = False
+            for _ in range(8):
+                result = await client.call_tool(
+                    "list_laravel_docs", {"version": "12.x"}, raise_on_error=False
+                )
+                if result.is_error:
+                    assert "Rate limit" in result.content[0].text
+                    saw_limit = True
+                    break
+            assert saw_limit, "budget never ran out despite burst 8 at 1 rps"
+
+            # ~1.2s at 1 rps refills a token; the client recovers.
+            await asyncio.sleep(1.2)
+            recovered = await client.call_tool(
+                "list_laravel_docs", {"version": "12.x"}, raise_on_error=False
+            )
+            assert not recovered.is_error
+
+    async def test_no_limiter_means_no_throttling(self, test_docs_dir):
+        server = create_mcp_server(
+            "TestServer", test_docs_dir, "12.x", transform_mode=None
+        )
+        async with Client(server) as client:
+            for _ in range(5):
+                result = await client.call_tool(
+                    "list_laravel_docs", {"version": "12.x"}, raise_on_error=False
+                )
+                assert not result.is_error
+
+    async def test_throttled_requests_still_counted_in_metrics(self, test_docs_dir):
+        """Registration order contract: metrics sits outside the limiter, so
+        a throttled request is still visible in laravel_mcp_requests_total."""
+        server = create_mcp_server(
+            "TestServer", test_docs_dir, "12.x", transform_mode=None,
+            rate_limiter=limiter(1.0, 6),
+        )
+        async with Client(server) as client:
+            attempts = 0
+            for _ in range(8):
+                attempts += 1
+                result = await client.call_tool(
+                    "list_laravel_docs", {"version": "12.x"}, raise_on_error=False
+                )
+                if result.is_error:
+                    break
+
+        from metrics import render_prometheus
+        out = render_prometheus(metrics.registry)
+        assert f'laravel_mcp_requests_total{{method="tools/call"}} {attempts}' in out
+
+
+class TestCorruptCorpusDegradation:
+    def test_search_survives_hostile_bytes_in_the_corpus(self, temp_dir):
+        version_dir = Path(temp_dir) / "12.x"
+        version_dir.mkdir(parents=True)
+        (version_dir / "broken.md").write_bytes(b"\xff\xfe\x00broken\x00bytes\xff")
+        (version_dir / "routing.md").write_text(
+            "# Routing\n\n## Basics\n\nRoutes are registered in web.php with "
+            "plenty of surrounding words so scoring has something to rank.\n"
+        )
+        result = search_laravel_docs_data(temp_dir, "routing", "12.x")
+        assert "error" not in result
+        assert result["results"]
+        assert result["results"][0]["file"] == "12.x/routing.md"


### PR DESCRIPTION
Third v0.13.0 sub-project (spec and plan in `docs/superpowers/`).

- **Opt-in rate limiting** — `--rate-limit RPS` / `RATE_LIMIT_RPS` wires FastMCP's token-bucket middleware; off by default so nothing changes for existing deployments. The burst defaults to `max(10, 2×RPS)` because the limiter counts the MCP initialize handshake against the bucket (probed: burst 2 self-throttled before the first tool call). One global bucket, documented honestly as a throughput cap — without auth there's no client identity for per-client fairness. Registered inside the metrics middleware so throttled requests still appear in `laravel_mcp_requests_total` (ordering pinned by test).
- **Degradation pins, not machinery** — probing showed the "graceful degradation" roadmap item was mostly delivered incrementally but unpinned. Two new tests capture it (search survives hostile bytes in the corpus; throttled clients get a clean error and recover on refill), and the roadmap item is checked off citing the accumulated mechanisms rather than pretending this PR built them.
- **Report-only benchmarks** — `pytest -m bench --no-cov -s` over the real repo corpus through the in-memory client: p50/p95/max per operation printed against the v1.0.0 sub-100ms target, never asserted (latency gates on shared runners are flake factories). First numbers: warm search p95 **3.7ms**, section reads **1.4ms**, docs info **4.6ms**; one-time index build ~101ms. The 100ms criterion is effectively already met.

857 unit/protocol + 8 e2e + 3 bench green; coverage 81.4% (gate 80); ruff/mypy clean.

Post-merge follow-up (same constraint as the e2e step): an informational Harness bench step on main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional HTTP rate limiting with configurable request rates and burst capacity.
  * Added command-line and environment-variable settings for rate-limit configuration.
  * Throttled requests now receive consistent responses, while stdio transport remains unaffected.

* **Bug Fixes**
  * Improved recovery when request capacity is exhausted.
  * Enhanced search resilience when documentation contains invalid or corrupted bytes.

* **Documentation**
  * Documented rate-limiting behavior, configuration, exclusions, and latency benchmarks.

* **Tests**
  * Added latency benchmarks and expanded rate-limiting, validation, recovery, and metrics coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->